### PR TITLE
fix(cockpit): no false 'another extension owns the custom editor' warning on resume

### DIFF
--- a/packages/pi-cockpit/src/claude-editor.ts
+++ b/packages/pi-cockpit/src/claude-editor.ts
@@ -153,6 +153,22 @@ export class CockpitClaudeEditor extends CustomEditor {
 
 /** Build the editor factory Cockpit installs when a gated feature is on. */
 export function createCockpitClaudeEditorFactory(options: CockpitClaudeEditorOptions) {
-	return (tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
+	const factory = (tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
 		new CockpitClaudeEditor(tui, theme, keybindings, options);
+	// Global-symbol marker so a later (possibly re-evaluated) extension instance
+	// can recognise its own factory left in pi's editor slot across resume/reload
+	// and never misreport it as owned by another extension.
+	(factory as { [COCKPIT_EDITOR_FACTORY_MARKER]?: true })[COCKPIT_EDITOR_FACTORY_MARKER] = true;
+	return factory;
 }
+
+/** True when the factory in pi's editor slot is one Cockpit installed. */
+export function isCockpitClaudeEditorFactory(factory: unknown): boolean {
+	return (
+		typeof factory === "function" &&
+		(factory as { [COCKPIT_EDITOR_FACTORY_MARKER]?: true })[COCKPIT_EDITOR_FACTORY_MARKER] === true
+	);
+}
+
+/** Global registry key (same symbol identity across module re-evaluations). */
+export const COCKPIT_EDITOR_FACTORY_MARKER = Symbol.for("cockpit.claudeEditorFactory");

--- a/packages/pi-cockpit/src/fullscreen-controller.ts
+++ b/packages/pi-cockpit/src/fullscreen-controller.ts
@@ -195,12 +195,14 @@ export function createFullscreenController(options: FullscreenControllerOptions 
 	const handleInput = (data: string): InputResult => {
 		const mouse = parseSgrMouseEvent(data) ?? parseX10MouseEvent(data);
 		if (!mouse) return undefined;
-		// Wheel buttons are 64 (up) / 65 (down) plus optional modifier bits; match
-		// on the wheel bit so modifier-wheel still scrolls the transcript instead of
-		// falling through to selection or native terminal scrolling.
-		if ((mouse.button & 64) !== 0) {
+		// Wheel: SGR 64/65 (plus modifier bits) is the modern encoding; buttons 4/5
+		// are the legacy urxvt/xterm wheel. Either must scroll the transcript and be
+		// consumed so the terminal never falls back to native alternate-screen
+		// scrollback (which would move the whole frame including the editor).
+		if ((mouse.button & 64) !== 0 || mouse.button === 4 || mouse.button === 5) {
 			selection.clear();
-			const delta = (mouse.button & 1) === 0 ? WHEEL_SCROLL_STEP : -WHEEL_SCROLL_STEP;
+			const isDown = (mouse.button & 1) === 1 || mouse.button === 5;
+			const delta = isDown ? -WHEEL_SCROLL_STEP : WHEEL_SCROLL_STEP;
 			scrollBy(delta);
 			return { consume: true };
 		}

--- a/packages/pi-cockpit/src/fullscreen-controller.ts
+++ b/packages/pi-cockpit/src/fullscreen-controller.ts
@@ -1,7 +1,7 @@
 import type { TUI } from "@earendil-works/pi-tui";
 import { EDITOR_END_SENTINEL, EDITOR_START_SENTINEL } from "./claude-editor.ts";
 import { acquireMouseReporting, flushMouseReportingWrites, type MouseReportingLease } from "./mouse-reporting.ts";
-import { parseSgrMouseEvent } from "./split-pane.ts";
+import { parseSgrMouseEvent, parseX10MouseEvent } from "./split-pane.ts";
 import {
 	createTranscriptSelectionController,
 	type TranscriptSelectionController,
@@ -193,7 +193,7 @@ export function createFullscreenController(options: FullscreenControllerOptions 
 	};
 
 	const handleInput = (data: string): InputResult => {
-		const mouse = parseSgrMouseEvent(data);
+		const mouse = parseSgrMouseEvent(data) ?? parseX10MouseEvent(data);
 		if (!mouse) return undefined;
 		// Wheel buttons are 64 (up) / 65 (down) plus optional modifier bits; match
 		// on the wheel bit so modifier-wheel still scrolls the transcript instead of

--- a/packages/pi-cockpit/src/index.ts
+++ b/packages/pi-cockpit/src/index.ts
@@ -20,7 +20,7 @@ import {
 	createEditorBottomSentinel,
 	type EditorBottomController,
 } from "./editor-bottom.ts";
-import { createCockpitClaudeEditorFactory } from "./claude-editor.ts";
+import { createCockpitClaudeEditorFactory, isCockpitClaudeEditorFactory } from "./claude-editor.ts";
 import { detectTerminalCompatibility } from "./terminal-capability.ts";
 import {
 	COCKPIT_FULLSCREEN_MARKER,
@@ -619,9 +619,21 @@ export default function (pi: ExtensionAPI): void {
 	// is never hot-toggled. If another extension owns the editor factory, fail
 	// closed with one warning and leave both gated features inert.
 	const installClaudeEditor = (ctx: ExtensionContext): void => {
-		if (claudeEditorInstalled) return;
 		if (!config.doubleEscapeClearInput && !config.fullscreenInput) return;
-		if (ctx.ui.getEditorComponent()) {
+		const current = ctx.ui.getEditorComponent();
+		if (isCockpitClaudeEditorFactory(current)) {
+			// Our own factory is already in pi's editor slot — it survives a resume
+			// or reload that cleared the module state but not the slot. Treat it as
+			// installed and never misreport it as a foreign owner.
+			claudeEditorInstalled = true;
+			return;
+		}
+		if (claudeEditorInstalled && current === undefined) {
+			// pi cleared our editor (e.g. resetExtensionUI on a session switch) but
+			// the flag is stale; reinstall below instead of staying inert.
+			claudeEditorInstalled = false;
+		}
+		if (current) {
 			if (!claudeEditorForeignWarned) {
 				claudeEditorForeignWarned = true;
 				ctx.ui.notify(
@@ -644,7 +656,8 @@ export default function (pi: ExtensionAPI): void {
 	};
 
 	const clearClaudeEditor = (ctx: ExtensionContext): void => {
-		if (!claudeEditorInstalled) return;
+		const current = ctx.ui.getEditorComponent();
+		if (!claudeEditorInstalled && !isCockpitClaudeEditorFactory(current)) return;
 		try {
 			ctx.ui.setEditorComponent(undefined);
 		} catch {

--- a/packages/pi-cockpit/src/split-pane.ts
+++ b/packages/pi-cockpit/src/split-pane.ts
@@ -8,6 +8,9 @@ import { attachViewportStability, type ViewportStabilityPatch } from "./viewport
 import { acquireMouseReporting, flushMouseReportingWrites, type MouseReportingLease } from "./mouse-reporting.ts";
 
 const SGR_MOUSE = /^\u001b\[<(\d+);(\d+);(\d+)([Mm])$/;
+// Legacy X10 mouse: ESC [ M + 3 bytes (button+32, x+32, y+32). Some terminals fall
+// back to it when SGR (1006) is not active; wheel still uses 64/65 in the button byte.
+const X10_MOUSE = /^\u001b\[M(.{3})$/s;
 
 export const DEFAULT_SIDEBAR_WIDTH = 40;
 export const MIN_SIDEBAR_WIDTH = 32;
@@ -35,6 +38,21 @@ export function parseSgrMouseEvent(data: string): SgrMouseEvent | undefined {
 	const y = Number(match[3]);
 	if (![button, x, y].every(Number.isFinite) || x < 1 || y < 1) return undefined;
 	return { button, x, y, release: match[4] === "m", motion: (button & 32) !== 0 };
+}
+
+/** Parse the legacy X10 mouse encoding into the same SgrMouseEvent shape. */
+export function parseX10MouseEvent(data: string): SgrMouseEvent | undefined {
+	const match = data.match(X10_MOUSE);
+	if (!match) return undefined;
+	const raw = match[1].charCodeAt(0) - 32;
+	const x = match[1].charCodeAt(1) - 32;
+	const y = match[1].charCodeAt(2) - 32;
+	if (x < 1 || y < 1 || raw < 0) return undefined;
+	const release = (raw & 3) === 3;
+	// Normalise the release bits (X10 uses 3) away so downstream routing sees the
+	// same button value as an SGR release (0) and satisfies (button & 31) === 0.
+	const button = release ? raw & ~3 : raw;
+	return { button, x, y, release, motion: (raw & 32) !== 0 };
 }
 
 type RenderFunction = TUI["render"];

--- a/packages/pi-cockpit/tests/claude-editor.test.ts
+++ b/packages/pi-cockpit/tests/claude-editor.test.ts
@@ -7,7 +7,9 @@ import {
 	DoubleEscapeGate,
 	EDITOR_END_SENTINEL,
 	EDITOR_START_SENTINEL,
+	COCKPIT_EDITOR_FACTORY_MARKER,
 	createCockpitClaudeEditorFactory,
+	isCockpitClaudeEditorFactory,
 	type CockpitClaudeEditorOptions,
 } from "../src/claude-editor.ts";
 
@@ -193,6 +195,23 @@ test("factory builds a working CockpitClaudeEditor", () => {
 	editor.handleInput("\x1b");
 	editor.handleInput("\x1b");
 	assert.equal(editor.getText(), "");
+});
+
+test("factory marker identifies Cockpit's own editor factory (across module re-eval)", () => {
+	const factory = createCockpitClaudeEditorFactory({ doubleEscapeClearInput: true, emitEditorMarkers: false });
+	assert.equal(isCockpitClaudeEditorFactory(factory), true, "own factory is recognised");
+	// A re-evaluated module sees the same global symbol, so a factory tagged with
+	// a locally-constructed Symbol.for copy is still recognised.
+	const reEvaluatedTag = { [Symbol.for("cockpit.claudeEditorFactory")]: true };
+	const foreign = Object.assign(() => ({}), reEvaluatedTag);
+	assert.equal(COCKPIT_EDITOR_FACTORY_MARKER, Symbol.for("cockpit.claudeEditorFactory"), "global symbol identity holds");
+	assert.equal(isCockpitClaudeEditorFactory(foreign), true, "tagged function is recognised");
+});
+
+test("factory marker rejects non-Cockpit factories", () => {
+	assert.equal(isCockpitClaudeEditorFactory(undefined), false);
+	assert.equal(isCockpitClaudeEditorFactory(() => ({})), false);
+	assert.equal(isCockpitClaudeEditorFactory({ render() {} }), false);
 });
 
 test("editor: onClear fires once when the draft is cleared", () => {

--- a/packages/pi-cockpit/tests/fullscreen-controller.test.ts
+++ b/packages/pi-cockpit/tests/fullscreen-controller.test.ts
@@ -178,6 +178,25 @@ test("X10 drag (non-SGR fallback) selects and copies like SGR", async () => {
 	controller.dispose();
 });
 
+test("legacy urxvt wheel buttons 4/5 scroll instead of starting a drag", () => {
+	let transcript = Array.from({ length: 40 }, (_, i) => `line ${i}`);
+	const harness = makeHarness(() => buildLines(transcript, EDITOR_BLOCK, CHROME), 20);
+	const controller = createFullscreenController({
+		subscribeInput: (handler) => {
+			harness.attachInput(handler);
+			return () => harness.attachInput(undefined);
+		},
+	});
+	controller.attach(harness.tui);
+	harness.inputHandler?.("\x1b[<4;5;10M"); // button 4 = legacy wheel up
+	harness.inputHandler?.("\x1b[<4;5;10M");
+	assert.equal(controller.getScrollOffset(), 6, "legacy wheel-up scrolls the transcript");
+	harness.inputHandler?.("\x1b[<5;5;10M"); // button 5 = legacy wheel down
+	assert.equal(controller.getScrollOffset(), 3, "legacy wheel-down returns toward live bottom");
+	assert.ok(!harness.render()[14].includes("\x1b[7m"), "legacy wheel never starts a selection");
+	controller.dispose();
+});
+
 test("modifier-wheel still scrolls the transcript instead of starting a drag", () => {
 	let transcript = Array.from({ length: 40 }, (_, i) => `line ${i}`);
 	const harness = makeHarness(() => buildLines(transcript, EDITOR_BLOCK, CHROME), 20);

--- a/packages/pi-cockpit/tests/fullscreen-controller.test.ts
+++ b/packages/pi-cockpit/tests/fullscreen-controller.test.ts
@@ -134,6 +134,50 @@ test("wheel scroll keeps editor+chrome physically fixed and clamps to the viewpo
 	controller.dispose();
 });
 
+test("X10 wheel (non-SGR fallback) still scrolls the transcript", () => {
+	let transcript = Array.from({ length: 40 }, (_, i) => `line ${i}`);
+	const harness = makeHarness(() => buildLines(transcript, EDITOR_BLOCK, CHROME), 20);
+	const controller = createFullscreenController({
+		subscribeInput: (handler) => {
+			harness.attachInput(handler);
+			return () => harness.attachInput(undefined);
+		},
+	});
+	controller.attach(harness.tui);
+	const x10 = (btn: number, x: number, y: number) => `\x1b[M${String.fromCharCode(btn + 32, x + 32, y + 32)}`;
+	harness.inputHandler?.(x10(64, 5, 10)); // X10 wheel-up
+	harness.inputHandler?.(x10(64, 5, 10));
+	assert.equal(controller.getScrollOffset(), 6, "X10 wheel scrolls the transcript");
+	harness.inputHandler?.(x10(65, 5, 10)); // X10 wheel-down
+	assert.equal(controller.getScrollOffset(), 3, "X10 wheel-down returns toward live bottom");
+	assert.ok(!harness.render()[14].includes("\x1b[7m"), "X10 wheel never starts a selection");
+	controller.dispose();
+});
+
+test("X10 drag (non-SGR fallback) selects and copies like SGR", async () => {
+	let transcript = Array.from({ length: 20 }, (_, i) => `line ${i}`);
+	let copied: string | undefined;
+	const harness = makeHarness(() => buildLines(transcript, EDITOR_BLOCK, CHROME), 20);
+	const controller = createFullscreenController({
+		subscribeInput: (handler) => {
+			harness.attachInput(handler);
+			return () => harness.attachInput(undefined);
+		},
+		isCopyOnSelect: () => true,
+		copy: async (text) => {
+			copied = text;
+		},
+	});
+	controller.attach(harness.tui);
+	const x10 = (btn: number, x: number, y: number) => `\x1b[M${String.fromCharCode(btn + 32, x + 32, y + 32)}`;
+	harness.inputHandler?.(x10(0, 1, 1)); // press button 0 at (1,1)
+	harness.inputHandler?.(x10(32, 6, 2)); // motion to (6,2)
+	harness.inputHandler?.(x10(3, 6, 2)); // release
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(copied, "line 5\nline 6", "X10 drag copies the selected rows");
+	controller.dispose();
+});
+
 test("modifier-wheel still scrolls the transcript instead of starting a drag", () => {
 	let transcript = Array.from({ length: 40 }, (_, i) => `line ${i}`);
 	const harness = makeHarness(() => buildLines(transcript, EDITOR_BLOCK, CHROME), 20);


### PR DESCRIPTION
## Follow-up fix: false "another extension owns the custom editor" warning on resume/reload

Merged in #3 as v0.15.0, but a follow-up regression surfaced: **when fullscreenInput (or double-Escape clear) is enabled and the user resumes a session, cockpit shows**

```
Operation aborted
Warning: Cockpit double-Escape clear / fullscreen input unavailable: another extension owns the custom editor
Resumed session
```

**Root cause**: a session switch resets the extension's module state (the `claudeEditorInstalled` flag) while pi's editor slot can still hold Cockpit's own factory. `installClaudeEditor` then saw a truthy `getEditorComponent()` with a false install flag and misreported **our own editor** as foreign-owned. (The "Operation aborted" line is pi's own `session.abort()` message on switch — expected, not from this fix.)

**Fix**: the Cockpit editor factory is now tagged with a global `Symbol.for` marker so a re-evaluated module can recognise its own factory left in the slot:
- `installClaudeEditor`: own factory in slot → treat as installed (no warning), never a false foreign-owner report;
- `clearClaudeEditor`: removes our factory even when the local flag is stale;
- a stale flag with a cleared slot reinstalls instead of staying inert;
- a genuinely foreign editor still fails closed with the warning.

## Testing

- `pi-cockpit`: `npm run typecheck` clean; `npm test` 543/543 green (incl. 2 new marker tests: own factory recognised across a simulated module re-evaluation, foreign/plain factories rejected).
- Merged cleanly onto latest `upstream/master` (no conflicts).

## Wheel hardening (appended while PR open)

The "wheel scrolls the input box instead of the transcript" symptom can occur when the terminal reports wheel in a format the fullscreen handler does not recognise, so the event is not consumed and the terminal falls back to its native alternate-screen scrollback (moving the whole frame, editor included). Added:

- **Legacy X10 mouse decoding** (`\x1b[M` + 3 bytes) as a fallback when SGR (1006) is not active — wheel and drag-selection now behave identically in both encodings (release bits normalised so routing checks hold).
- **Legacy urxvt wheel buttons 4/5** now scroll instead of falling through into drag-selection.

Both covered by new tests; full suite 546/546 green.
