### PR TITLE
feat(experts): Experts Mode — opt-in policy layer for teammate + Maestro

### DIFF
--- a/.pi/agents/team-worker.md
+++ b/.pi/agents/team-worker.md
@@ -1,6 +1,7 @@
 ---
 name: team-worker
 description: "Unified worker agent for team pipelines. Executes role-specific logic loaded from a role_spec file within a built-in task lifecycle (discover, execute, report)."
+taskType: development
 tools:
   - Read
   - Write

--- a/.pi/skills/experts/SKILL.md
+++ b/.pi/skills/experts/SKILL.md
@@ -57,7 +57,7 @@ The Maestro campaign itself uses only the unified Session/Run surface (identical
 - Simple command chain: `maestro run start --platform pi "<intent>" --chain analyze plan execute --no-dispatch --workflow-root .`
 - Completion: `maestro run done [run_id] --verdict done|done-with-concerns|needs-retry|blocked --workflow-root .`
 
-Mode control is in-process (no CLI subprocess): call `setMode("experts"|"normal", cwd)` and render `formatExpertsStatusPanel(cwd)` from `packages/pi-maestro-teammate/src/experts-mode/`. The `/experts` command (on|off|status) wraps exactly these two calls.
+Mode control is in-process (no CLI subprocess): call `setMode("experts"|"normal", cwd)` and render `formatExpertsStatusPanel(cwd)` from `packages/pi-maestro-teammate/src/experts-mode/`. The `/experts` command wraps these calls plus the panel views — subcommands `on|off|status|roster|waiting|harvest` (default `status`) — and shows a read-only TUI overlay (Esc/q/Enter close) when the interactive UI is available, falling back to a notify.
 
 </cli_surface>
 

--- a/.pi/skills/experts/SKILL.md
+++ b/.pi/skills/experts/SKILL.md
@@ -233,3 +233,19 @@ See package `src/experts-mode/config/experts-rules.example.json`. Copy fields in
 
 - `/experts roster` or `/experts config` — show profiles (model/channel/skills when set)
 
+## Preloaded Maestro skills (defaults)
+
+Package `default-rules.json` roster ships Maestro skill presets (project `.experts-rules.json` can override):
+
+| Role | Default skills | Why |
+|------|----------------|-----|
+| explorer | _(none)_ | Pure code discovery; do not auto-invoke maestro-learn |
+| planner | `maestro`, `maestro-next` | Chain classify / Session plan surface |
+| analyst | `maestro-spec` | Constraints / architecture rules awareness |
+| general-executor | `maestro-companion` | Small scoped execute with evidence |
+| reviewer | `team-review`, `maestro-knowledge` | Review pipeline + knowledge harvest |
+| verifier | `maestro-session-seal`, `maestro-knowledge` | Seal / knowledge close-out |
+| workflow | `maestro-ralph`, `team-coordinate` | Closed-loop + multi-role coordinate |
+
+Dispatch injects skills as `<!-- experts-skills -->` guidance via `applyExpertProfiles`. Skills are names only — agents load via `skill://name` / host skill loader.
+

--- a/.pi/skills/experts/SKILL.md
+++ b/.pi/skills/experts/SKILL.md
@@ -198,3 +198,38 @@ While `leaderWaiting` is true: do not claim done, do not start dependent synthes
 <note>
 This is NOT the Qoder Canvas pipeline: it is the Pi-native experts pipeline with an enforced hard gate (host adapter turns a deny into a blocking pre-tool result carrying a teammate rewrite). The hard-gate enforcement is stronger than Qoder's soft reminder — treat a deny as a hard stop, rewrite the call, and dispatch.
 </note>
+
+## Expert profiles config (model / channel / skills)
+
+Project file: `<cwd>/.experts-rules.json` (merged over package defaults).
+
+### Schema (roster entry)
+
+| Field | Meaning |
+|-------|---------|
+| `agent` | Teammate role name (not a model id) |
+| `defaultTaskType` | Routing phase when stage/triage omit taskType |
+| `channel` | Provider prefix or alias key under `channels` |
+| `model` | Preferred model: `provider/model` **or** bare id (joined with channel) |
+| `fallbackModels` | Ordered fallbacks |
+| `thinking` | Preferred thinking level |
+| `skills` | Skill names injected as `skill://` guidance on dispatch |
+
+### Channels
+
+```json
+{ "channels": { "cpa": "cpa-responses", "sub2": "sub2-responses" } }
+```
+
+### Precedence (model)
+
+`explicit task.model` > **expert roster profile** > `applyModelRouting` (taskType / roleMappings / inherit)
+
+### Example
+
+See package `src/experts-mode/config/experts-rules.example.json`. Copy fields into project `.experts-rules.json`.
+
+### CLI
+
+- `/experts roster` or `/experts config` — show profiles (model/channel/skills when set)
+

--- a/.pi/skills/experts/SKILL.md
+++ b/.pi/skills/experts/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: experts
+description: "Experts-bound Maestro campaign — force mode=experts and drive the canonical Session/Run loop. Arguments: <intent|on|off|status|roster|waiting|harvest> [-y] [-c] [--amend] [--dry-run]"
+allowed-tools: Read Write Edit Bash Glob Grep teammate maestro observe
+disable-model-invocation: false
+session-mode: none
+---
+
+<teammate_contract>
+
+- `background: false` is the default. Use foreground dispatch whenever the result determines the current answer or next action.
+- Use `background: true` only for independent work. If this turn must consume a background result, call `observe` exactly once with `action: "wait"` and a bounded timeout before continuing; never continue independently while the result is pending.
+- Otherwise end the turn and wait for the automatic `teammate-complete` notification. Do not rely on `SendMessage`, `team_msg`, or hook callbacks as completion signals.
+- Never silently ignore an unfinished dispatch.
+
+</teammate_contract>
+
+<required_reading>
+~/.maestro/workflows/run-mode.md
+~/.maestro/workflows/orchestrator-run-loop.md
+~/.maestro/prepare/maestro.md
+</required_reading>
+
+<host_mirror>
+
+Pi mirrors canonical Session/Run state automatically:
+
+- Advance only with `todo({ action: "next" })`; do not create or update mirror tasks manually.
+- Goal completion is derived from terminal chain state and clean gates.
+- After compaction, reattach through the current Run's `brief.command`.
+
+</host_mirror>
+
+<deferred_reading>
+- [experts-bind.md](refs/experts-bind.md) — read for the D3 birth packet / waiting rules before the first stage dispatch
+</deferred_reading>
+
+<purpose>
+Experts-bound Maestro campaign: force `setMode("experts")` for the working directory and then run the same Session/Run loop as `/maestro`. Every stage dispatch goes through a teammate carrying a `taskType` resolved from stagePolicies before keyword triage; the Lead never implements business code itself (P5 hard gate). This skill is the single entry point for any work that should run in experts mode.
+</purpose>
+
+<pi_context_contract>
+
+- Consume the injected Topic Session resolution and ReuseAssessment as read-only routing evidence.
+- Accept upstream only from same-Session sealed outputs.
+- Resolve each `argument_requirements` entry through `required`, `missing`, `type`, `source`, optional `default`, and `question`.
+- Treat the birth packet as compact routing; load the execution protocol from `brief.command`.
+- Under experts mode the stage is auto-injected from session.json (P4.1) — never set MAESTRO_STAGE manually.
+
+</pi_context_contract>
+
+<cli_surface>
+
+The Maestro campaign itself uses only the unified Session/Run surface (identical to `/maestro`):
+
+- Single step: `maestro run start "<intent>" --cmd <step> --arg "<step input>" --platform pi --workflow-root .`
+- Simple command chain: `maestro run start --platform pi "<intent>" --chain analyze plan execute --no-dispatch --workflow-root .`
+- Completion: `maestro run done [run_id] --verdict done|done-with-concerns|needs-retry|blocked --workflow-root .`
+
+Mode control is in-process (no CLI subprocess): call `setMode("experts"|"normal", cwd)` and render `formatExpertsStatusPanel(cwd)` from `packages/pi-maestro-teammate/src/experts-mode/`. The `/experts` command (on|off|status) wraps exactly these two calls.
+
+</cli_surface>
+
+<interface>
+Only these user flags are accepted (same semantics as `/maestro`):
+
+- `-y` — skip all confirmation/clarification interactions, use default choices. Never bypasses high-risk classification, confidence <60, ambiguity requiring user input, failed gates, or drift escalation.
+- `-c` — continue the unique live compatible Session.
+- `--amend` — amend that Session's goal; remaining text is the change request.
+- `--dry-run` — show chain without executing.
+
+Subcommands (mode panel surface):
+
+- `on` — force `setMode("experts", cwd)` then print the status panel.
+- `off` — `setMode("normal", cwd)` then print the status panel.
+- `status` — print `formatExpertsStatusPanel(cwd)` (default when no subcommand).
+- `roster` — list project roster roles (role ≠ model; each role has agent + default taskType).
+- `waiting` — leaderWaiting state + in-flight expert units.
+- `harvest` — pending P7 knowhow suggestions (never auto-promote).
+
+All other text is intent. Unknown flags are not silently reinterpreted.
+</interface>
+
+<invariants>
+1. **Session is the source of truth** — session.json.orchestration owns links, goals, decisions; a Run is a single execution attempt.
+2. **One chain** — every task uses the same Session/Run protocol as `/maestro`; no experts-private Session type.
+3. **Runtime owns mutation** — the prompt never writes session.json/run.json and never auto-uses admin chain commands.
+4. **Verdict advances** — execution steps advance only through `session done --verdict`; decision steps only through `session decide`.
+5. **Waiting forbids claiming done** — while `leaderWaiting` is true (activeCount > 0) the Lead must not report done, must not start dependent synthesis, and must not spam re-dispatches; consume `teammate-complete`/settle first.
+6. **Lead P5 allowlist only** — the Lead writes only report.md, outputs/**, .workflow/**, notes/** (plus rules allowlist); business write/edit/bash is delegated via teammate.
+7. **Role ≠ model** — agents are role names (explorer, general-executor, …); routing owns models and the panel/records never render model ids.
+8. **D3 session next does NOT silent teammate** — advancing to a new stage injects the stage birth plan only; the Lead must explicitly call teammate with the stage pipeline (taskType from stagePolicies).
+9. **Stage pipeline beats triage** — stagePolicies fill taskType before keyword triage; explicit taskType still wins.
+</invariants>
+
+<state_machine>
+
+<states>
+S_PARSE — parse intent, flags and subcommand
+S_STATUS — render `formatExpertsStatusPanel` (status / default)
+S_MODE — switch mode (`on` / `off` via setMode)
+S_ROSTER — show roster roles (role ≠ model)
+S_WAITING — show leaderWaiting + in-flight experts
+S_HARVEST — show pending P7 knowledge suggestions
+S_CONTINUE — locate the unique live Session
+S_AMEND — audited goal amendment
+S_CLASSIFY — select the smallest sufficient initial chain
+S_CREATE — create via `session create --chain-file`
+S_CONFIRM — confirm classification unless `-y`
+S_RUN_LOOP — execute `orchestrator-run-loop.md`
+S_FALLBACK — request missing intent or disambiguation
+</states>
+
+<transitions>
+S_PARSE:
+  → S_STATUS WHEN: subcommand is status (or none) / `--dry-run` of mode
+  → S_MODE WHEN: subcommand is on|off
+  → S_ROSTER WHEN: subcommand is roster
+  → S_WAITING WHEN: subcommand is waiting
+  → S_HARVEST WHEN: subcommand is harvest
+  → S_AMEND WHEN: `--amend`
+  → S_CONTINUE WHEN: `-c`
+  → S_CLASSIFY WHEN: intent present
+  → S_FALLBACK OTHERWISE
+
+S_CONTINUE:
+  → S_RUN_LOOP WHEN: exactly one live compatible Session
+  → S_FALLBACK WHEN: paused (suggest /maestro-ralph -c for audited recovery), none or multiple
+
+S_AMEND:
+  → S_RUN_LOOP WHEN: shared amend protocol committed
+  → END WHEN: cancelled or blocked
+
+S_CLASSIFY:
+  → S_RUN_LOOP WHEN: existing compatible Session found (do not rebuild)
+  → S_CREATE WHEN: narrow/single-step chain
+  → S_FALLBACK WHEN: confidence < 60
+
+S_CREATE → S_RUN_LOOP WHEN: `-y` AND risk ≠ high AND confidence ≥ 60
+S_CREATE → S_CONFIRM WHEN: `-y` AND (risk == high OR confidence < 60)
+S_CREATE → S_CONFIRM OTHERWISE
+S_CREATE → S_FALLBACK WHEN: creation fails (delete temp file, report error)
+S_CONFIRM → S_RUN_LOOP WHEN: confirmed
+S_CONFIRM → S_FALLBACK WHEN: cancelled
+
+S_STATUS → END
+S_MODE → S_STATUS (print panel after switching)
+S_ROSTER → END
+S_WAITING → END
+S_HARVEST → END
+</transitions>
+
+<actions>
+
+### A_MODE
+
+Call `setMode("experts" | "normal", cwd)` (in-process library, no subprocess). Then print `formatExpertsStatusPanel(cwd)` so the switch is observable. Mode persists in `.experts-mode.json` under cwd; the panel's Mode line confirms it.
+
+### A_CLASSIFY
+
+Read deferred `maestro.md`. Record matched evidence, excluded alternatives and confidence before creation. Minimum chain rules are identical to `/maestro`:
+
+| Intent evidence | Initial chain |
+|---|---|
+| narrow fix/change | analyze → plan → execute → review/test as required |
+| broad rewrite/migration | analyze-macro → scope decision → plan/roadmap path |
+| brainstorm/explore | brainstorm, then only Skill-proposed continuation |
+| formal specification | blueprint → plan path |
+| existing compatible Session | do not rebuild; enter shared loop |
+
+Roadmap is inferred only for multi-release evidence. Quality depth follows project specs, UI evidence needs frontend verification, and every executable command is resolved by Run Runtime.
+
+### A_CREATE
+
+Assemble and create per `prepare/maestro.md` §3–§4. Same policy as `/maestro`: no formal decision nodes from this skill; quality/goal/scope checks are Skill steps that own a Run and may return a proposal. For narrow/single-step chains generate a minimal implicit boundary_contract. Do not inline unescaped JSON.
+
+### A_BIRTH (D3)
+
+When `session next` advances the chain, the Runtime injects the stage birth plan (see `formatStageBirthPacket` — stage, pipeline taskTypes, agents, leader instructions). That injection is NOT a dispatch: the Lead must explicitly call `teammate` with the stage pipeline, passing `taskType` (from stagePolicies) and the agent role, never a model id. Read `refs/experts-bind.md` for the full birth packet / waiting rules before the first stage dispatch.
+
+### A_WAIT
+
+While `leaderWaiting` is true: do not claim done, do not start dependent synthesis, do not re-dispatch spam. Consume the automatic `teammate-complete` notification (or `observe` wait), synthesize the RESULT into report/outputs, then `noteExpertsSettled` clears waiting.
+
+</actions>
+
+</state_machine>
+
+<success_criteria>
+- Mode is forced to `experts` via `setMode` and confirmed by the status panel before any stage dispatch.
+- Campaign CLI stays within `maestro session/run ...` lifecycle commands; mode commands stay in-process (`setMode` + `formatExpertsStatusPanel`).
+- Every stage dispatch carries a role agent + a taskType resolved from stagePolicies; no model id is ever passed or rendered.
+- Leader waiting is never claimed done; settle consumes results and advances verdicts.
+- Lead mutations are within the P5 allowlist (report.md, outputs/**, .workflow/**, notes/**); business code is delegated.
+- Session remains the source of truth; Runtime owns all session.json/run.json mutation.
+</success_criteria>
+
+<note>
+This is NOT the Qoder Canvas pipeline: it is the Pi-native experts pipeline with an enforced hard gate (host adapter turns a deny into a blocking pre-tool result carrying a teammate rewrite). The hard-gate enforcement is stronger than Qoder's soft reminder — treat a deny as a hard stop, rewrite the call, and dispatch.
+</note>

--- a/.pi/skills/experts/refs/experts-bind.md
+++ b/.pi/skills/experts/refs/experts-bind.md
@@ -1,0 +1,50 @@
+# experts-bind — D3 birth packet & waiting rules
+
+Short binding ref for the Experts skill. Read before the first stage dispatch of a campaign.
+
+## D3: `session next` does NOT silent teammate
+
+When `session next` advances the chain, the Runtime injects the **stage birth plan** into the
+session context (library: `formatStageBirthPacket`). That injection is compact routing — it is
+NOT a dispatch and never spawns anyone.
+
+The Lead must explicitly call `teammate` with the stage pipeline:
+
+- `taskType` comes from `stagePolicies` for the stage (stage pipeline beats keyword triage);
+  explicit taskType still wins.
+- `agent` is a role name (explorer / analyst / planner / general-executor / reviewer / …) —
+  never a model id.
+- No `model` field. Routing owns models.
+- Stage is auto-injected from session.json (P4.1) — never set `MAESTRO_STAGE` manually.
+
+Birth packet fields (from `formatStageBirthPacket`):
+
+| Field | Meaning |
+|---|---|
+| stage | normalized stage name (execute, analyze, plan, review, …) |
+| pipeline | ordered taskTypes (e.g. `explore → analysis`) |
+| agents | role agents per pipeline step |
+| leader instructions | compact routing guidance for the dispatch |
+
+Example (analyze stage): `Stage birth: "analyze"` → dispatch `explorer` taskType=explore,
+then `analyst` taskType=analysis with dependsOn on the explore task.
+
+## Waiting rules
+
+While `leaderWaiting` is true (`leaderWaitingCount > 0`, agent ids in `leaderWaitingAgentIds`):
+
+1. **Do not claim done** — no `session done`, no final synthesis, no seal while experts run.
+2. **Do not re-dispatch spam** — the stage pipeline is dispatched once; do not re-fire the same
+   tasks while the previous wave is in flight.
+3. **Do not start dependent synthesis** — wait for the automatic `teammate-complete`
+   notification (or one bounded `observe` wait) before consuming results.
+4. **Consume settle** — after results arrive, call `noteExpertsSettled` (decrements waiting,
+   clears settled in-flight units) before continuing the loop.
+5. **P7 harvest** — settle with expert RESULT content may stage knowhow suggestions; never
+   auto-promote — harvest is suggest-only (`maestro knowledge stage`).
+
+## P5 allowlist (Lead-only writes)
+
+`report.md`, `outputs/**`, `.workflow/**`, `notes/**` + rules `hardGate.leaderAllowPaths`.
+Everything else — business code, config, tests — goes through a teammate dispatch
+(development / testing / review … per stage).

--- a/.pi/skills/maestro/SKILL.md
+++ b/.pi/skills/maestro/SKILL.md
@@ -200,3 +200,10 @@ Read `ralph-amend-goal.md`, use `session status {session_id}` for the snapshot, 
 - Chain adaptation is Skill-proposed and atomically applied by the producing Run.
 - Normal output and recommendations contain only `maestro run ...` lifecycle commands.
 </success_criteria>
+
+## Experts Mode (P5.1)
+
+- When experts mode is ON: the Lead only owns maestro session/run lifecycle + teammate dispatch + synthesize RESULT into report/outputs; business write/edit/bash is delegated to experts (P5 hard gate).
+- Stage is auto-injected from session.json (P4.1) — no manual MAESTRO_STAGE; stagePolicies fill taskType before keyword triage.
+- Optional vice-lead: for multi-step stage pipelines, dispatch agent=workflow taskType=planning to decompose/dispatch the DAG; the Lead still owns session done/check/seal.
+- Continuation: prefer automatic continuation when authority=automatic (session next/done loop).

--- a/.pi/skills/maestro/SKILL.md
+++ b/.pi/skills/maestro/SKILL.md
@@ -207,3 +207,5 @@ Read `ralph-amend-goal.md`, use `session status {session_id}` for the snapshot, 
 - Stage is auto-injected from session.json (P4.1) — no manual MAESTRO_STAGE; stagePolicies fill taskType before keyword triage.
 - Optional vice-lead: for multi-step stage pipelines, dispatch agent=workflow taskType=planning to decompose/dispatch the DAG; the Lead still owns session done/check/seal.
 - Continuation: prefer automatic continuation when authority=automatic (session next/done loop).
+- Full experts interaction entry: `/experts` (same flags/run-loop as this skill + force experts mode + status panel).
+- This skill remains valid under mode=experts; hard-gate and stagePolicies still apply.

--- a/.pi/skills/team-arch-opt/SKILL.md
+++ b/.pi/skills/team-arch-opt/SKILL.md
@@ -81,7 +81,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-coordinate/SKILL.md
+++ b/.pi/skills/team-coordinate/SKILL.md
@@ -125,7 +125,7 @@ User provides task description
 When coordinator spawns workers, use `team-worker` agent with role-spec path:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: {run_dir}/work/team/role-specs/<role>.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-issue/SKILL.md
+++ b/.pi/skills/team-issue/SKILL.md
@@ -82,7 +82,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team
@@ -104,7 +104,7 @@ Execute built-in Phase 1 (task discovery) -> role Phase 2-4 -> built-in Phase 5 
 **Parallel spawn** (Batch mode, N explorer or M implementer instances):
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>-<N>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>-<N>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-lifecycle-v4/SKILL.md
+++ b/.pi/skills/team-lifecycle-v4/SKILL.md
@@ -78,7 +78,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-perf-opt/SKILL.md
+++ b/.pi/skills/team-perf-opt/SKILL.md
@@ -92,7 +92,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-review/SKILL.md
+++ b/.pi/skills/team-review/SKILL.md
@@ -73,7 +73,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-swarm/SKILL.md
+++ b/.pi/skills/team-swarm/SKILL.md
@@ -81,7 +81,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/.pi/skills/team-testing/SKILL.md
+++ b/.pi/skills/team-testing/SKILL.md
@@ -74,7 +74,7 @@ Parse `$ARGUMENTS`:
 Coordinator spawns workers using this template:
 
 ```
-teammate({ agent: "team-worker", tasks: [{ name: "<role>", prompt: `## Role Assignment
+teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: "<role>", taskType: "development", prompt: `## Role Assignment
 role: <role>
 role_spec: <skill_root>/roles/<role>/role.md
 session: {run_dir}/work/team

--- a/packages/pi-maestro-flow/src/extension/index.ts
+++ b/packages/pi-maestro-flow/src/extension/index.ts
@@ -3132,7 +3132,11 @@ Examples: { argv: ["session","status"] }, { argv: ["run","done","run-abc","--ver
   const teammatePermissionBroker: TeammatePermissionBroker = async (call, ctx) => {
     const planBlock = onToolCallPlan(call, approvalMode === "bypassPermissions");
     if (planBlock) return { action: "deny", reason: planBlock.reason };
-    const hookBlock = await hookAdapter.beforeToolCall(call, ctx);
+    // CV-01: child tools must not hit Lead hard-gate — mark expertsCaller=expert.
+    const hookBlock = await hookAdapter.beforeToolCall(
+      { ...call, expertsCaller: "expert" as const },
+      ctx,
+    );
     if (hookBlock) return { action: "deny", reason: hookBlock.reason };
     const block = await permissionController.authorize(
       call,
@@ -3157,6 +3161,7 @@ Examples: { argv: ["session","status"] }, { argv: ["run","done","run-abc","--ver
         const call = { toolName, input };
         const planBlock = onToolCallPlan(call, approvalMode === "bypassPermissions");
         if (planBlock) return { block: true, reason: planBlock.reason };
+        // GUI path is Leader-originated; keep default expertsCaller=leader.
         const hookBlock = await hookAdapter.beforeToolCall(call, ctx);
         signal.throwIfAborted();
         if (hookBlock) return { block: true, reason: hookBlock.reason };

--- a/packages/pi-maestro-flow/src/hooks/pi-adapter.ts
+++ b/packages/pi-maestro-flow/src/hooks/pi-adapter.ts
@@ -300,19 +300,18 @@ export function registerCodexHookAdapter(pi: ExtensionAPI, options: AdapterOptio
   };
 
   const beforeToolCall = async (
-    event: PermissionToolCall & { toolCallId?: string },
+    event: PermissionToolCall & { toolCallId?: string; expertsCaller?: "leader" | "expert" },
     ctx: ExtensionContext,
   ): Promise<{ block: true; reason: string } | undefined> => {
-    if (!state.active) return;
     const names = toolMatchValues(event.toolName);
-
-    // Experts Mode P1/P5 hard-gate (before user hooks):
-    // deny blocks with teammate rewrite guidance; ask injects guidance; allowlist paths pass.
-    // State file: <cwd>/.experts-mode.json or EXPERTS_MODE_STATE.
+    // CV-01 / HV-01: Lead hard-gate runs even when Codex hooks are inactive/untrusted.
+    // Expert (teammate child relay) skips the gate so workers can write business files.
+    const expertsCaller = event.expertsCaller === "expert" ? "expert" : "leader";
     try {
       const gate = evaluateHardGate(event.toolName, {
         cwd: ctx.cwd,
         toolInput: event.input,
+        caller: expertsCaller,
       });
       if (gate.decision === "deny") {
         const rewrite = gate.rewriteSuggestion;
@@ -330,6 +329,9 @@ export function registerCodexHookAdapter(pi: ExtensionAPI, options: AdapterOptio
     } catch {
       // Never fail tool path if experts-mode state is unreadable.
     }
+
+    // Remaining Codex hooks still require trusted hooks.json.
+    if (!state.active) return;
 
     const outputs = await execute("PreToolUse", names, {
       ...turnInput("PreToolUse", ctx, state, getPermissionMode()),

--- a/packages/pi-maestro-flow/src/hooks/pi-adapter.ts
+++ b/packages/pi-maestro-flow/src/hooks/pi-adapter.ts
@@ -36,6 +36,7 @@ import {
   type HookReviewUiState,
 } from "./review-tui.ts";
 import { runMaestroHookInstaller } from "./installer.ts";
+import { evaluateHardGate } from "pi-maestro-teammate/experts-mode";
 import type {
   PermissionMode,
   PermissionToolCall,
@@ -304,6 +305,32 @@ export function registerCodexHookAdapter(pi: ExtensionAPI, options: AdapterOptio
   ): Promise<{ block: true; reason: string } | undefined> => {
     if (!state.active) return;
     const names = toolMatchValues(event.toolName);
+
+    // Experts Mode P1/P5 hard-gate (before user hooks):
+    // deny blocks with teammate rewrite guidance; ask injects guidance; allowlist paths pass.
+    // State file: <cwd>/.experts-mode.json or EXPERTS_MODE_STATE.
+    try {
+      const gate = evaluateHardGate(event.toolName, {
+        cwd: ctx.cwd,
+        toolInput: event.input,
+      });
+      if (gate.decision === "deny") {
+        const rewrite = gate.rewriteSuggestion;
+        const rewriteLine = rewrite
+          ? ` [rewrite] teammate taskType=${rewrite.taskType} agent=${rewrite.agent}`
+            + (rewrite.stage ? ` stage=${rewrite.stage}` : "")
+          : "";
+        return { block: true, reason: `${gate.reason}${rewriteLine}` };
+      }
+      if (gate.decision === "ask" && event.toolCallId) {
+        const warn = `[experts-mode] ${gate.reason}`;
+        const prev = state.toolContext.get(event.toolCallId) ?? [];
+        state.toolContext.set(event.toolCallId, [...prev, warn]);
+      }
+    } catch {
+      // Never fail tool path if experts-mode state is unreadable.
+    }
+
     const outputs = await execute("PreToolUse", names, {
       ...turnInput("PreToolUse", ctx, state, getPermissionMode()),
       tool_name: names[0],

--- a/packages/pi-maestro-flow/src/statusline/statusline.ts
+++ b/packages/pi-maestro-flow/src/statusline/statusline.ts
@@ -208,6 +208,17 @@ export function renderKnowledgePendingMarker(value: string | undefined): string 
 	return colored("phase", `KNOW ?`);
 }
 
+/**
+ * P7b: experts settle harvest marker from `experts-harvest` extension status
+ * (`HARVEST n` or `HARVEST n · pitfall:1 …`).
+ */
+export function renderExpertsHarvestMarker(value: string | undefined): string {
+	if (!value) return "";
+	const count = /^HARVEST (\d+)/.exec(value.trim())?.[1];
+	if (!count) return colored("phase", "HARVEST");
+	return colored("phase", `HV● ${count}`);
+}
+
 function renderContextPressure(value: string | undefined, width: number): string {
 	if (!value) return "";
 	const normalized = value.replace(/^CTX\s+/i, "").trim();
@@ -325,6 +336,7 @@ function renderLine1(
 	effortStatus: string | undefined,
 	evolStatus: string | undefined,
 	knowledgeStatus: string | undefined,
+	harvestStatus?: string | undefined,
 ): string {
 	const safeWidth = Math.max(1, width);
 	const modeFull = renderPlanModeStatus(modeStatus, approvalStatus, 80);
@@ -334,6 +346,7 @@ function renderLine1(
 	const autoCompactionCompact = renderAutoCompactionMode(compactionStatus, 48);
 	const evolText = renderEvolMarker(evolStatus);
 	const knowledgeText = renderKnowledgePendingMarker(knowledgeStatus);
+	const harvestText = renderExpertsHarvestMarker(harvestStatus);
 	const autoCompactionNarrow = renderAutoCompactionMode(compactionStatus, 1);
 	const effort = formatEffortStatus(effortStatus);
 	const modelText = colored("model", `${ICONS.model} ${shortenModel(rs.model)}${effort ? ` · ${effort}` : ""}`);
@@ -357,16 +370,16 @@ function renderLine1(
 
 	const candidates = safeWidth >= 80
 		? [
-			[modeFull, modelText, contextFull, autoCompactionFull, evolText, knowledgeText, toolCallText, dirGitText, tokenText],
-			[modeCompact, modelText, contextCompact, autoCompactionCompact, evolText, toolCallText, dirGitText, tokenText],
-			[modeCompact, modelText, contextCompact, autoCompactionCompact, evolText, toolCallText, dirGitText],
+			[modeFull, modelText, contextFull, autoCompactionFull, evolText, knowledgeText, harvestText, toolCallText, dirGitText, tokenText],
+			[modeCompact, modelText, contextCompact, autoCompactionCompact, evolText, knowledgeText, harvestText, toolCallText, dirGitText, tokenText],
+			[modeCompact, modelText, contextCompact, autoCompactionCompact, evolText, harvestText, toolCallText, dirGitText],
 			[modeCompact, modelText, contextCompact, autoCompactionCompact, toolCallText, dirGitText],
 			[modeCompact, modelText, contextCompact, autoCompactionCompact, dirText],
 			[modeNarrow, autoCompactionNarrow, contextCompact, modelText],
 		]
 		: safeWidth >= 48
 			? [
-				[modeCompact, autoCompactionCompact, modelText, contextCompact, evolText, dirGitText],
+				[modeCompact, autoCompactionCompact, modelText, contextCompact, evolText, harvestText, dirGitText],
 				[modeCompact, autoCompactionCompact, modelText, contextCompact, dirGitText],
 				[modeCompact, autoCompactionCompact, modelText, contextCompact],
 				[modeNarrow, autoCompactionNarrow, contextCompact, modelText],
@@ -581,7 +594,8 @@ export function installStatusline(
 					const swarmStatus = footerData.getExtensionStatuses().get("maestro-swarm");
 					const evolStatus = footerData.getExtensionStatuses().get("self-evolve");
 					const knowledgeStatus = footerData.getExtensionStatuses().get("maestro-knowledge-pending");
-					lines.push(renderLine1(rs, activeToolCalls, cwd, width, modeStatus, approvalStatus, compactionModeStatus, effortStatus, evolStatus, knowledgeStatus));
+					const harvestStatus = footerData.getExtensionStatuses().get("experts-harvest");
+					lines.push(renderLine1(rs, activeToolCalls, cwd, width, modeStatus, approvalStatus, compactionModeStatus, effortStatus, evolStatus, knowledgeStatus, harvestStatus));
 
 					const pressureLine = renderPressureLine(pressureStatus, width);
 					if (pressureLine) lines.push(pressureLine);

--- a/packages/pi-maestro-flow/src/tools/delegate.ts
+++ b/packages/pi-maestro-flow/src/tools/delegate.ts
@@ -15,6 +15,8 @@ export interface DelegateParams {
   prompt?: string;
   tool?: string;
   mode?: "analysis" | "write";
+  /** Optional explicit taskType; when omitted, derived from mode / experts triage. */
+  taskType?: string;
   name?: string;
   model?: string;
   rule?: string;
@@ -41,7 +43,7 @@ export async function executeDelegate(
     };
   }
 
-  // Build task with mode context
+  // Build task with mode context (text prefix stays for prompt semantics).
   let task = params.prompt;
   if (params.mode) {
     task = `MODE: ${params.mode}\n\n${task}`;
@@ -53,12 +55,22 @@ export async function executeDelegate(
   // Resolve model from tool name or explicit model
   const model = params.model ?? params.tool;
 
+  // Structured taskType for applyModelRouting / Experts Mode — not only MODE text.
+  // analysis mode → analysis; write mode → development; explicit taskType wins.
+  const taskType = params.taskType
+    ?? (params.mode === "analysis"
+      ? "analysis"
+      : params.mode === "write"
+        ? "development"
+        : undefined);
+
   try {
     const [result] = await runTeammate(
       {
         tasks: [{
           agent: "general",
           prompt: task,
+          ...(taskType ? { taskType } : {}),
           name: params.name,
           model,
           cwd: params.cwd,

--- a/packages/pi-maestro-flow/test/experts-mode-delegate.test.ts
+++ b/packages/pi-maestro-flow/test/experts-mode-delegate.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/**
+ * Lightweight contract checks for delegate taskType mapping.
+ * Full executeDelegate is integration-heavy; we verify the pure mapping used by the patch.
+ */
+function resolveDelegateTaskType(params: {
+  taskType?: string;
+  mode?: "analysis" | "write";
+}): string | undefined {
+  return params.taskType
+    ?? (params.mode === "analysis"
+      ? "analysis"
+      : params.mode === "write"
+        ? "development"
+        : undefined);
+}
+
+test("delegate mode analysis maps to taskType analysis", () => {
+  assert.equal(resolveDelegateTaskType({ mode: "analysis" }), "analysis");
+});
+
+test("delegate mode write maps to taskType development", () => {
+  assert.equal(resolveDelegateTaskType({ mode: "write" }), "development");
+});
+
+test("explicit taskType wins over mode", () => {
+  assert.equal(resolveDelegateTaskType({ mode: "write", taskType: "review" }), "review");
+});
+
+test("no mode and no taskType stays undefined (experts triage may fill later)", () => {
+  assert.equal(resolveDelegateTaskType({}), undefined);
+});

--- a/packages/pi-maestro-teammate/package.json
+++ b/packages/pi-maestro-teammate/package.json
@@ -53,6 +53,9 @@
       "types": "./types/public/v1/model-routing.d.ts",
       "default": "./src/public/v1/model-routing.ts"
     },
+    "./experts-mode": {
+      "default": "./src/experts-mode/index.ts"
+    },
     "./v1/mailbox": {
       "types": "./types/public/v1/mailbox.d.ts",
       "default": "./src/public/v1/mailbox.ts"

--- a/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
+++ b/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
@@ -108,7 +108,6 @@
       "**/outputs/**",
       ".workflow/**",
       "**/.workflow/**",
-      ".experts-mode.json",
       "notes/**",
       "**/notes/**"
     ],

--- a/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
+++ b/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
@@ -196,37 +196,51 @@
       "defaultTaskType": "explore",
       "label": "Code explorer",
       "capabilities": ["explore", "search"],
-      "tools": ["read", "ffgrep", "fffind", "bash"]
+      "tools": ["read", "ffgrep", "fffind", "bash"],
+      "skills": []
     },
     "planner": {
       "agent": "planner",
       "defaultTaskType": "planning",
       "label": "Planner",
-      "capabilities": ["planning"]
+      "capabilities": ["planning"],
+      "skills": ["maestro", "maestro-next"]
     },
     "analyst": {
       "agent": "analyst",
       "defaultTaskType": "analysis",
       "label": "Analyst",
-      "capabilities": ["analysis", "debug", "review"]
+      "capabilities": ["analysis", "debug", "review"],
+      "skills": ["maestro-spec"]
     },
     "reviewer": {
       "agent": "reviewer",
       "defaultTaskType": "review",
       "label": "Reviewer",
-      "capabilities": ["review"]
+      "capabilities": ["review"],
+      "skills": ["team-review", "maestro-knowledge"]
     },
     "general-executor": {
       "agent": "general-executor",
       "defaultTaskType": "development",
       "label": "Implementer",
-      "capabilities": ["development", "testing"]
+      "capabilities": ["development", "testing"],
+      "skills": ["maestro-companion"]
     },
     "verifier": {
       "agent": "verifier",
       "defaultTaskType": "verification",
       "label": "Verifier",
-      "capabilities": ["verification"]
+      "capabilities": ["verification"],
+      "skills": ["maestro-session-seal", "maestro-knowledge"]
+    },
+    "workflow": {
+      "agent": "workflow",
+      "defaultTaskType": "planning",
+      "label": "Vice-lead / DAG coordinator",
+      "capabilities": ["planning", "coordinate"],
+      "skills": ["maestro-ralph", "team-coordinate"],
+      "enabled": true
     }
   },
   "stageAliases": {

--- a/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
+++ b/packages/pi-maestro-teammate/src/experts-mode/config/default-rules.json
@@ -1,0 +1,247 @@
+{
+  "version": 1,
+  "defaultTaskType": "development",
+  "defaultAgent": "general-executor",
+  "defaultPipeline": ["explore", "planning", "development", "review"],
+  "pipelines": {
+    "tiny_fix": ["development", "review"],
+    "investigation": ["explore", "analysis"],
+    "debug": ["explore", "debug", "development", "review"],
+    "full_feature": ["explore", "planning", "development", "review"]
+  },
+  "taskTypes": {
+    "explore": {
+      "agent": "explorer",
+      "heavy": true,
+      "keywords": [
+        "搜索", "查找", "定位", "调用链", "入口", "explore", "search", "find",
+        "where is", "call chain", "trace", "grep", "扫代码", "代码库"
+      ]
+    },
+    "planning": {
+      "agent": "planner",
+      "heavy": true,
+      "keywords": [
+        "计划", "方案", "设计", "架构", "拆分", "roadmap", "plan", "design",
+        "architect", "分解", "如何实现"
+      ]
+    },
+    "analysis": {
+      "agent": "analyst",
+      "heavy": true,
+      "keywords": [
+        "分析", "判断", "评估", "权衡", "root cause", "analysis", "trade-off",
+        "可行性", "对比"
+      ]
+    },
+    "debug": {
+      "agent": "analyst",
+      "heavy": true,
+      "keywords": [
+        "调试", "报错", "bug", "崩溃", "失败", "debug", "fix", "error",
+        "stack", "异常", "不工作"
+      ]
+    },
+    "development": {
+      "agent": "general-executor",
+      "heavy": true,
+      "keywords": [
+        "实现", "编写", "修改", "重构", "加上", "实现功能", "implement",
+        "code", "write", "refactor", "改代码", "开发"
+      ]
+    },
+    "review": {
+      "agent": "reviewer",
+      "heavy": true,
+      "keywords": [
+        "审查", "review", "code review", "检查改动", "收口", "质量"
+      ]
+    },
+    "testing": {
+      "agent": "general-executor",
+      "heavy": true,
+      "keywords": [
+        "测试", "单测", "补测", "test", "unit test", "coverage", "验收测试"
+      ]
+    },
+    "verification": {
+      "agent": "verifier",
+      "heavy": true,
+      "keywords": [
+        "验证", "验收", "verify", "acceptance", "回归"
+      ]
+    }
+  },
+  "lightKeywords": [
+    "你好", "谢谢", "什么是", "解释一下", "简答", "确认", "yes", "no",
+    "ok", "继续", "status", "状态"
+  ],
+  "hardGate": {
+    "default": "allow",
+    "tools": {
+      "write": "deny",
+      "edit": "deny",
+      "bash": "deny",
+      "bash_bg": "deny",
+      "read": "allow",
+      "ffgrep": "allow",
+      "fffind": "allow",
+      "teammate": "allow",
+      "observe": "allow",
+      "todo": "allow",
+      "goal": "allow",
+      "plan-enter": "allow",
+      "plan-update": "allow",
+      "plan-confirm": "allow",
+      "plan-exit": "allow",
+      "plan-status": "allow",
+      "plan-review": "allow",
+      "run-control": "allow",
+      "mcp": "allow",
+      "smart_search": "ask",
+      "browser": "ask"
+    },
+    "leaderAllowPaths": [
+      "report.md",
+      "**/report.md",
+      "outputs/**",
+      "**/outputs/**",
+      ".workflow/**",
+      "**/.workflow/**",
+      ".experts-mode.json",
+      "notes/**",
+      "**/notes/**"
+    ],
+    "bashAllowPrefixes": [
+      "maestro ",
+      "git status",
+      "git diff",
+      "git log",
+      "git show",
+      "npm test",
+      "npm run test",
+      "node --test",
+      "node --experimental-transform-types --test",
+      "rg ",
+      "ls ",
+      "pwd"
+    ]
+  },
+  "orchestrator": {
+    "disciplineReminder": true,
+    "viceLead": true
+  },
+  "stagePolicies": {
+    "analyze": {
+      "pipeline": [
+        { "name": "analyze-explore", "agent": "explorer", "taskType": "explore" },
+        { "name": "analyze-analyst", "agent": "analyst", "taskType": "analysis", "dependsOn": ["analyze-explore"] }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json"],
+      "forbidMain": ["broad codebase rewrite", "feature implementation"],
+      "parallelism": "serial"
+    },
+    "plan": {
+      "pipeline": [
+        { "name": "plan-primary", "agent": "planner", "taskType": "planning" }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json", "plan artifacts"],
+      "forbidMain": ["implement the plan in the same step"],
+      "parallelism": "serial"
+    },
+    "execute": {
+      "pipeline": [
+        { "name": "execute-dev", "agent": "general-executor", "taskType": "development" }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json"],
+      "forbidMain": ["feature implementation", "large multi-file business rewrites"],
+      "parallelism": "wave"
+    },
+    "review": {
+      "pipeline": [
+        { "name": "review-primary", "agent": "analyst", "taskType": "review" }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json"],
+      "forbidMain": ["silent drive-by fixes without review findings"],
+      "independent": true,
+      "parallelism": "serial"
+    },
+    "test": {
+      "pipeline": [
+        { "name": "test-primary", "agent": "general-executor", "taskType": "testing" }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json"],
+      "forbidMain": ["implement missing features instead of testing"],
+      "parallelism": "serial"
+    },
+    "debug": {
+      "pipeline": [
+        { "name": "debug-primary", "agent": "analyst", "taskType": "debug" }
+      ],
+      "leaderMayWrite": ["report.md", "outputs/*.json"],
+      "forbidMain": ["unbounded speculative rewrites"],
+      "parallelism": "serial"
+    }
+  },
+  "settle": {
+    "autoClearWaiting": true,
+    "knowledgeHarvest": true,
+    "maxSuggestions": 5,
+    "maxBodyChars": 4000,
+    "autoStage": false
+  },
+  "roster": {
+    "explorer": {
+      "agent": "explorer",
+      "defaultTaskType": "explore",
+      "label": "Code explorer",
+      "capabilities": ["explore", "search"],
+      "tools": ["read", "ffgrep", "fffind", "bash"]
+    },
+    "planner": {
+      "agent": "planner",
+      "defaultTaskType": "planning",
+      "label": "Planner",
+      "capabilities": ["planning"]
+    },
+    "analyst": {
+      "agent": "analyst",
+      "defaultTaskType": "analysis",
+      "label": "Analyst",
+      "capabilities": ["analysis", "debug", "review"]
+    },
+    "reviewer": {
+      "agent": "reviewer",
+      "defaultTaskType": "review",
+      "label": "Reviewer",
+      "capabilities": ["review"]
+    },
+    "general-executor": {
+      "agent": "general-executor",
+      "defaultTaskType": "development",
+      "label": "Implementer",
+      "capabilities": ["development", "testing"]
+    },
+    "verifier": {
+      "agent": "verifier",
+      "defaultTaskType": "verification",
+      "label": "Verifier",
+      "capabilities": ["verification"]
+    }
+  },
+  "stageAliases": {
+    "maestro-analyze": "analyze",
+    "maestro-plan": "plan",
+    "maestro-execute": "execute",
+    "maestro-review": "review",
+    "quality-review": "review",
+    "quality-test": "test",
+    "quality-debug": "debug",
+    "auto-test": "test",
+    "analyze-macro": "analyze",
+    "development": "execute",
+    "planning": "plan",
+    "testing": "test",
+    "verification": "test"
+  }
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/config/experts-rules.example.json
+++ b/packages/pi-maestro-teammate/src/experts-mode/config/experts-rules.example.json
@@ -12,8 +12,9 @@
       "channel": "cpa",
       "model": "deepseek-v4-flash",
       "thinking": "low",
-      "skills": ["smart-search-cli"],
-      "capabilities": ["explore"]
+      "skills": [],
+      "capabilities": ["explore", "search"],
+      "tools": ["read", "ffgrep", "fffind", "bash"]
     },
     "planner": {
       "agent": "planner",
@@ -22,37 +23,60 @@
       "channel": "cpa",
       "model": "grok-4.5",
       "thinking": "max",
-      "skills": ["maestro"],
+      "skills": ["maestro", "maestro-next"],
       "capabilities": ["planning"]
     },
     "analyst": {
       "agent": "analyst",
       "defaultTaskType": "analysis",
+      "label": "Analyst",
       "channel": "cpa",
       "model": "grok-4.5",
       "thinking": "max",
-      "skills": [],
-      "capabilities": ["analysis", "debug"]
+      "skills": ["maestro-spec"],
+      "capabilities": ["analysis", "debug", "review"]
     },
     "general-executor": {
       "agent": "general-executor",
       "defaultTaskType": "development",
+      "label": "Implementer",
       "channel": "cpa",
       "model": "deepseek-v4-flash",
       "fallbackModels": ["sub2-responses/gpt-5.6-terra"],
       "thinking": "max",
-      "skills": [],
+      "skills": ["maestro-companion"],
       "capabilities": ["development", "testing"]
     },
     "reviewer": {
       "agent": "reviewer",
       "defaultTaskType": "review",
+      "label": "Reviewer",
       "channel": "cpa",
       "model": "deepseek-v4-flash",
       "fallbackModels": ["cpa-responses/grok-4.5", "sub2-responses/gpt-5.6-terra"],
       "thinking": "max",
-      "skills": [],
+      "skills": ["team-review", "maestro-knowledge"],
       "capabilities": ["review"]
+    },
+    "verifier": {
+      "agent": "verifier",
+      "defaultTaskType": "verification",
+      "label": "Verifier",
+      "channel": "cpa",
+      "model": "deepseek-v4-flash",
+      "thinking": "max",
+      "skills": ["maestro-session-seal", "maestro-knowledge"],
+      "capabilities": ["verification"]
+    },
+    "workflow": {
+      "agent": "workflow",
+      "defaultTaskType": "planning",
+      "label": "Vice-lead / DAG coordinator",
+      "channel": "cpa",
+      "model": "grok-4.5",
+      "thinking": "max",
+      "skills": ["maestro-ralph", "team-coordinate"],
+      "capabilities": ["planning", "coordinate"]
     }
   },
   "settle": {

--- a/packages/pi-maestro-teammate/src/experts-mode/config/experts-rules.example.json
+++ b/packages/pi-maestro-teammate/src/experts-mode/config/experts-rules.example.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "channels": {
+    "cpa": "cpa-responses",
+    "sub2": "sub2-responses"
+  },
+  "roster": {
+    "explorer": {
+      "agent": "explorer",
+      "defaultTaskType": "explore",
+      "label": "Code explorer",
+      "channel": "cpa",
+      "model": "deepseek-v4-flash",
+      "thinking": "low",
+      "skills": ["smart-search-cli"],
+      "capabilities": ["explore"]
+    },
+    "planner": {
+      "agent": "planner",
+      "defaultTaskType": "planning",
+      "label": "Planner",
+      "channel": "cpa",
+      "model": "grok-4.5",
+      "thinking": "max",
+      "skills": ["maestro"],
+      "capabilities": ["planning"]
+    },
+    "analyst": {
+      "agent": "analyst",
+      "defaultTaskType": "analysis",
+      "channel": "cpa",
+      "model": "grok-4.5",
+      "thinking": "max",
+      "skills": [],
+      "capabilities": ["analysis", "debug"]
+    },
+    "general-executor": {
+      "agent": "general-executor",
+      "defaultTaskType": "development",
+      "channel": "cpa",
+      "model": "deepseek-v4-flash",
+      "fallbackModels": ["sub2-responses/gpt-5.6-terra"],
+      "thinking": "max",
+      "skills": [],
+      "capabilities": ["development", "testing"]
+    },
+    "reviewer": {
+      "agent": "reviewer",
+      "defaultTaskType": "review",
+      "channel": "cpa",
+      "model": "deepseek-v4-flash",
+      "fallbackModels": ["cpa-responses/grok-4.5", "sub2-responses/gpt-5.6-terra"],
+      "thinking": "max",
+      "skills": [],
+      "capabilities": ["review"]
+    }
+  },
+  "settle": {
+    "knowledgeHarvest": true,
+    "autoStage": false
+  }
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
@@ -1,0 +1,245 @@
+import { trackInFlight } from "./inflight.ts";
+import { resolveMaestroStageFromWorkspace, setMaestroStageEnvIfUnset } from "./maestro-stage.ts";
+import { getMode } from "./mode.ts";
+import { recordLastDispatch } from "./observe.ts";
+import { loadRules } from "./rules.ts";
+import { primaryStageAssignment, writeActiveStage } from "./stage-policy.ts";
+import { classifyIntent } from "./triage.ts";
+import { setLeaderWaiting } from "./waiting.ts";
+import type {
+  ExpertsMode,
+  ExpertsRules,
+  TeammateParamsLike,
+  TeammateTaskLike,
+} from "./types.ts";
+
+export interface EnsureExpertsDispatchOptions {
+  mode?: ExpertsMode;
+  cwd?: string;
+  record?: boolean;
+  rules?: ExpertsRules;
+  /**
+   * P4: Maestro chain stage / command name.
+   * When set under experts mode, missing taskType is filled from stagePolicies
+   * before keyword triage.
+   */
+  stage?: string;
+}
+
+/** Meta attached by ensureExpertsDispatch when experts mode forced assignments. */
+export type ExpertsDispatchMeta = {
+  mode: ExpertsMode;
+  forced: boolean;
+  stage?: string;
+  stageForced?: boolean;
+  triage: Array<{ taskType?: string; agent?: string }>;
+};
+
+/**
+ * Ensure teammate-like params carry taskType/agent when Experts Mode is on.
+ * Does NOT set model — leave that to applyModelRouting / teammate-models.
+ *
+ * Call order (required):
+ *   ensureExpertsDispatch(params) → applyModelRouting(params, ...)
+ *
+ * The param contract is deliberately loose (`T extends object`): callers pass
+ * RunTeammateParams / teammate tool params whose task specs carry no index
+ * signature, so they do not structurally match TeammateParamsLike. We widen
+ * internally and preserve the caller's concrete type on the way out.
+ */
+export function ensureExpertsDispatch<T extends object>(
+  params: T,
+  opts: EnsureExpertsDispatchOptions = {},
+): T & { __experts?: ExpertsDispatchMeta } {
+  const p = params as T & TeammateParamsLike;
+  const cwd = opts.cwd ?? process.cwd();
+  const mode = opts.mode ?? getMode(cwd);
+  const record = opts.record !== false;
+  const rules = opts.rules ?? loadRules();
+  let stageHint =
+    opts.stage
+    || (typeof p.stage === "string" ? p.stage : undefined)
+    || (typeof process.env.MAESTRO_STAGE === "string" && process.env.MAESTRO_STAGE
+      ? process.env.MAESTRO_STAGE
+      : undefined);
+
+  // P4.1: auto-detect the Maestro stage from session.json when nothing else
+  // supplied, so stagePolicies apply without the Leader passing stage by hand.
+  if (!stageHint && mode === "experts") {
+    try {
+      const found = resolveMaestroStageFromWorkspace(cwd);
+      if (found?.stage) {
+        stageHint = found.stage;
+        try {
+          setMaestroStageEnvIfUnset(found.stage);
+        } catch {
+          // env set must not break dispatch
+        }
+      }
+    } catch {
+      // workspace scan must never break dispatch
+    }
+  }
+
+  if (mode !== "experts") {
+    if (record) {
+      recordLastDispatch({
+        mode: "normal",
+        taskType: firstTaskType(p),
+        agent: firstAgent(p),
+        model: firstModel(p),
+        forced: false,
+        at: new Date().toISOString(),
+        promptPreview: preview(p),
+      }, cwd);
+    }
+    return { ...params } as T & { __experts?: ExpertsDispatchMeta };
+  }
+
+  const tasks: TeammateTaskLike[] = Array.isArray(p.tasks) && p.tasks.length > 0
+    ? p.tasks
+    : [{
+      prompt: typeof p.prompt === "string" ? p.prompt : "",
+      agent: typeof p.agent === "string" ? p.agent : undefined,
+      taskType: typeof p.taskType === "string" ? p.taskType : undefined,
+      model: typeof p.model === "string" ? p.model : undefined,
+    }];
+
+  const stageAssignment = primaryStageAssignment(stageHint, rules);
+  let anyForced = false;
+  let stageForced = false;
+  const nextTasks = tasks.map((task) => {
+    if (typeof task.taskType === "string" && task.taskType) {
+      return {
+        ...task,
+        agent: task.agent || agentForType(String(task.taskType), rules),
+      };
+    }
+    // P4: stage policy primary assignment beats keyword triage.
+    if (stageAssignment) {
+      anyForced = true;
+      stageForced = true;
+      return {
+        ...task,
+        taskType: stageAssignment.taskType,
+        agent: task.agent || stageAssignment.agent,
+      };
+    }
+    const triage = classifyIntent(String(task.prompt || p.prompt || ""), rules);
+    anyForced = true;
+    return {
+      ...task,
+      taskType: triage.taskType,
+      agent: task.agent || triage.agent,
+    };
+  });
+
+  const out = {
+    ...params,
+    tasks: nextTasks,
+  } as T & {
+    taskType?: string;
+    agent?: string;
+    __experts?: ExpertsDispatchMeta;
+  };
+
+  if (!out.taskType && nextTasks[0]?.taskType) out.taskType = String(nextTasks[0].taskType);
+  if (!out.agent && nextTasks[0]?.agent) out.agent = String(nextTasks[0].agent);
+
+  out.__experts = {
+    mode,
+    forced: anyForced,
+    stage: stageAssignment?.stage || stageHint,
+    stageForced,
+    triage: nextTasks.map((t) => ({
+      taskType: t.taskType ? String(t.taskType) : undefined,
+      agent: t.agent ? String(t.agent) : undefined,
+    })),
+  };
+
+  if (record) {
+    recordLastDispatch({
+      mode: "experts",
+      taskType: nextTasks[0]?.taskType ? String(nextTasks[0].taskType) : undefined,
+      agent: nextTasks[0]?.agent ? String(nextTasks[0].agent) : undefined,
+      // model is observed only if caller already set it — we never assign models here.
+      model: nextTasks[0]?.model
+        ? String(nextTasks[0].model)
+        : (typeof p.model === "string" ? p.model : undefined),
+      forced: anyForced,
+      at: new Date().toISOString(),
+      promptPreview: preview(p),
+      stage: stageAssignment?.stage || stageHint,
+    }, cwd);
+    if (stageAssignment) {
+      try {
+        writeActiveStage(cwd, {
+          stage: stageAssignment.stage,
+          source: "stage-policy",
+          taskTypes: nextTasks.map((t) => String(t.taskType || "")),
+          agents: nextTasks.map((t) => String(t.agent || "")),
+          intentPreview: preview(p),
+          at: new Date().toISOString(),
+        });
+      } catch {
+        // ignore state write failures
+      }
+    }
+  }
+
+  // Qoder leaderWaiting: mark leader waiting when experts mode dispatches work.
+  try {
+    const names = nextTasks
+      .map((t) => (typeof t.name === "string" ? t.name : typeof t.agent === "string" ? t.agent : ""))
+      .filter(Boolean);
+    setLeaderWaiting(true, {
+      cwd,
+      activeDelta: nextTasks.length,
+      agentIds: names,
+    });
+    // P6: track in-flight experts for getStatus / canvas snapshot.
+    trackInFlight(
+      nextTasks.map((t, i) => ({
+        id: typeof t.name === "string" && t.name
+          ? t.name
+          : `${String(t.agent || "expert")}-${i}`,
+        name: typeof t.name === "string" ? t.name : undefined,
+        agent: typeof t.agent === "string" ? t.agent : undefined,
+        taskType: typeof t.taskType === "string" ? t.taskType : undefined,
+        stage: stageAssignment?.stage || stageHint,
+      })),
+      { cwd, stage: stageAssignment?.stage || stageHint },
+    );
+  } catch {
+    // state write must not break dispatch
+  }
+
+  return out;
+}
+
+function agentForType(taskType: string, rules: ExpertsRules): string {
+  return rules.taskTypes?.[taskType]?.agent || rules.defaultAgent || "general";
+}
+
+function preview(params: TeammateParamsLike): string {
+  const text = params.tasks?.[0]?.prompt ?? params.prompt ?? "";
+  return String(text).slice(0, 120);
+}
+
+function firstTaskType(params: TeammateParamsLike): string | undefined {
+  if (typeof params.taskType === "string") return params.taskType;
+  if (typeof params.tasks?.[0]?.taskType === "string") return params.tasks[0].taskType;
+  return undefined;
+}
+
+function firstAgent(params: TeammateParamsLike): string | undefined {
+  if (typeof params.agent === "string") return params.agent;
+  if (typeof params.tasks?.[0]?.agent === "string") return params.tasks[0].agent;
+  return undefined;
+}
+
+function firstModel(params: TeammateParamsLike): string | undefined {
+  if (typeof params.model === "string") return params.model;
+  if (typeof params.tasks?.[0]?.model === "string") return params.tasks[0].model;
+  return undefined;
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
@@ -1,8 +1,9 @@
+import { applyExpertProfiles } from "./expert-profile.ts";
 import { trackInFlight } from "./inflight.ts";
 import { resolveMaestroStageFromWorkspace, setMaestroStageEnvIfUnset } from "./maestro-stage.ts";
 import { getMode } from "./mode.ts";
 import { recordLastDispatch } from "./observe.ts";
-import { loadRules } from "./rules.ts";
+import { defaultRulesPath, loadRules } from "./rules.ts";
 import { primaryStageAssignment, writeActiveStage } from "./stage-policy.ts";
 import { classifyIntent } from "./triage.ts";
 import { setLeaderWaiting } from "./waiting.ts";
@@ -37,7 +38,8 @@ export type ExpertsDispatchMeta = {
 
 /**
  * Ensure teammate-like params carry taskType/agent when Experts Mode is on.
- * Does NOT set model — leave that to applyModelRouting / teammate-models.
+ * Then applyExpertProfiles may fill model/channel/skills from roster config
+ * (explicit task.model still wins). Keyword triage never invents models.
  *
  * Call order (required):
  *   ensureExpertsDispatch(params) → applyModelRouting(params, ...)
@@ -55,7 +57,7 @@ export function ensureExpertsDispatch<T extends object>(
   const cwd = opts.cwd ?? process.cwd();
   const mode = opts.mode ?? getMode(cwd);
   const record = opts.record !== false;
-  const rules = opts.rules ?? loadRules();
+  const rules = opts.rules ?? loadRules(defaultRulesPath(), cwd);
   let stageHint =
     opts.stage
     || (typeof p.stage === "string" ? p.stage : undefined)
@@ -134,7 +136,7 @@ export function ensureExpertsDispatch<T extends object>(
     };
   });
 
-  const out = {
+  let out = {
     ...params,
     tasks: nextTasks,
   } as T & {
@@ -212,6 +214,14 @@ export function ensureExpertsDispatch<T extends object>(
     );
   } catch {
     // state write must not break dispatch
+  }
+
+  // Roster profiles: preferred model/channel/skills (config-driven only).
+  // applyModelRouting still runs after this and will not override task.model.
+  try {
+    out = applyExpertProfiles(out, { cwd, rules, mode });
+  } catch {
+    // profile apply must never break dispatch
   }
 
   return out;

--- a/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/dispatch.ts
@@ -34,6 +34,10 @@ export type ExpertsDispatchMeta = {
   stage?: string;
   stageForced?: boolean;
   triage: Array<{ taskType?: string; agent?: string }>;
+  /** HV-03: how many leaderWaiting slots this dispatch reserved (+N). */
+  waitingDelta?: number;
+  /** Task ids/names reserved for waiting/inFlight (for early-return settle). */
+  waitingAgentIds?: string[];
 };
 
 /**
@@ -157,6 +161,8 @@ export function ensureExpertsDispatch<T extends object>(
       taskType: t.taskType ? String(t.taskType) : undefined,
       agent: t.agent ? String(t.agent) : undefined,
     })),
+    waitingDelta: 0,
+    waitingAgentIds: [],
   };
 
   if (record) {
@@ -190,13 +196,15 @@ export function ensureExpertsDispatch<T extends object>(
   }
 
   // Qoder leaderWaiting: mark leader waiting when experts mode dispatches work.
+  // HV-03: record waitingDelta on __experts so callers can settle on early return.
   try {
     const names = nextTasks
       .map((t) => (typeof t.name === "string" ? t.name : typeof t.agent === "string" ? t.agent : ""))
       .filter(Boolean);
+    const delta = nextTasks.length;
     setLeaderWaiting(true, {
       cwd,
-      activeDelta: nextTasks.length,
+      activeDelta: delta,
       agentIds: names,
     });
     // P6: track in-flight experts for getStatus / canvas snapshot.
@@ -212,6 +220,10 @@ export function ensureExpertsDispatch<T extends object>(
       })),
       { cwd, stage: stageAssignment?.stage || stageHint },
     );
+    if (out.__experts) {
+      out.__experts.waitingDelta = delta;
+      out.__experts.waitingAgentIds = names;
+    }
   } catch {
     // state write must not break dispatch
   }

--- a/packages/pi-maestro-teammate/src/experts-mode/expert-profile.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/expert-profile.ts
@@ -1,0 +1,175 @@
+/**
+ * Expert profile resolution — maps roster roles to preferred model / channel / skills.
+ *
+ * Precedence for model (applied only under experts mode):
+ *   explicit task.model > expert profile (roster) > applyModelRouting (taskType/roleMappings)
+ *
+ * This module never invents models from keywords. All model/channel/skills values
+ * come from project `.experts-rules.json` (or package defaults). Role name ≠ model id.
+ */
+import { getMode } from "./mode.ts";
+import { loadRules, defaultRulesPath } from "./rules.ts";
+import { resolveRosterEntry } from "./roster.ts";
+import type {
+  ExpertsMode,
+  ExpertsRules,
+  TeammateParamsLike,
+  TeammateTaskLike,
+} from "./types.ts";
+
+export const EXPERTS_SKILLS_START = "<!-- experts-skills:start -->";
+export const EXPERTS_SKILLS_END = "<!-- experts-skills:end -->";
+
+export interface ExpertProfileResolved {
+  id: string;
+  agent: string;
+  defaultTaskType: string;
+  model?: string;
+  fallbackModels?: string[];
+  thinking?: string;
+  channel?: string;
+  skills?: string[];
+  source: "roster" | "taskTypes-fallback";
+}
+
+/** Resolve channel alias via rules.channels, else return the raw channel string. */
+export function resolveChannel(
+  channel: string | undefined,
+  rules: ExpertsRules,
+): string | undefined {
+  const c = String(channel ?? "").trim();
+  if (!c) return undefined;
+  const alias = rules.channels?.[c] ?? rules.channels?.[c.toLowerCase()];
+  if (alias && String(alias).trim()) return String(alias).trim();
+  return c;
+}
+
+/**
+ * Build a full provider/model ref.
+ * - model with "/" is returned as-is
+ * - bare model + channel → `${resolvedChannel}/${model}`
+ * - bare model only → model
+ */
+export function resolveModelRef(
+  model: string | undefined,
+  channel: string | undefined,
+  rules: ExpertsRules,
+): string | undefined {
+  const m = String(model ?? "").trim();
+  if (!m) return undefined;
+  if (m.includes("/")) return m;
+  const ch = resolveChannel(channel, rules);
+  if (ch) return `${ch}/${m}`;
+  return m;
+}
+
+/** Lookup roster entry by agent / taskType / name and resolve model through channel. */
+export function resolveExpertProfile(
+  query: { agent?: string; taskType?: string; name?: string },
+  rules: ExpertsRules = loadRules(),
+): ExpertProfileResolved | undefined {
+  let entry =
+    (query.agent ? resolveRosterEntry(query.agent, rules) : undefined)
+    || (query.taskType ? resolveRosterEntry(query.taskType, rules) : undefined)
+    || (query.name ? resolveRosterEntry(query.name, rules) : undefined);
+  if (!entry) return undefined;
+
+  const model = resolveModelRef(entry.model, entry.channel, rules);
+  const fallbackModels = entry.fallbackModels
+    ?.map((f) => resolveModelRef(f, entry!.channel, rules) || f)
+    .filter(Boolean) as string[] | undefined;
+
+  return {
+    id: entry.id,
+    agent: entry.agent,
+    defaultTaskType: entry.defaultTaskType,
+    model,
+    fallbackModels: fallbackModels?.length ? fallbackModels : undefined,
+    thinking: entry.thinking,
+    channel: entry.channel,
+    skills: entry.skills,
+    source: (rules.roster || rules.expertProfiles) ? "roster" : "taskTypes-fallback",
+  };
+}
+
+function injectSkills(prompt: string | undefined, skills: string[]): string {
+  const base = String(prompt ?? "");
+  if (!skills.length) return base;
+  if (base.includes(EXPERTS_SKILLS_START)) return base;
+  const block = [
+    EXPERTS_SKILLS_START,
+    "Required skills for this expert (load via resource skill://name when available):",
+    ...skills.map((s) => `- ${s}`),
+    EXPERTS_SKILLS_END,
+  ].join("\n");
+  return base ? `${base}\n\n${block}` : block;
+}
+
+/**
+ * Apply expert roster profiles onto teammate params (experts mode only).
+ * Fills model / fallbackModels / thinking when unset; injects skills marker into prompt.
+ * Never overrides explicit task.model.
+ */
+export function applyExpertProfiles<T extends object>(
+  params: T,
+  opts: { cwd?: string; rules?: ExpertsRules; mode?: ExpertsMode } = {},
+): T {
+  const cwd = opts.cwd ?? process.cwd();
+  const mode = opts.mode ?? getMode(cwd);
+  if (mode !== "experts") return params;
+
+  const rules = opts.rules ?? loadRules(defaultRulesPath(), cwd);
+  const p = params as T & TeammateParamsLike;
+  const tasks = Array.isArray(p.tasks) ? p.tasks : undefined;
+
+  if (!tasks || tasks.length === 0) {
+    const profile = resolveExpertProfile(
+      {
+        agent: typeof p.agent === "string" ? p.agent : undefined,
+        taskType: typeof p.taskType === "string" ? p.taskType : undefined,
+      },
+      rules,
+    );
+    if (!profile) return params;
+    const out = { ...p } as T & TeammateParamsLike;
+    if (!out.model && profile.model) out.model = profile.model;
+    if (!out.fallbackModels && profile.fallbackModels) out.fallbackModels = profile.fallbackModels;
+    if (!out.thinking && profile.thinking) out.thinking = profile.thinking;
+    if (profile.skills?.length) {
+      out.prompt = injectSkills(
+        typeof out.prompt === "string" ? out.prompt : undefined,
+        profile.skills,
+      );
+    }
+    return out as T;
+  }
+
+  const nextTasks = tasks.map((task) => {
+    const t = { ...task } as TeammateTaskLike;
+    const profile = resolveExpertProfile(
+      {
+        agent: typeof t.agent === "string"
+          ? t.agent
+          : (typeof p.agent === "string" ? p.agent : undefined),
+        taskType: typeof t.taskType === "string"
+          ? t.taskType
+          : (typeof p.taskType === "string" ? p.taskType : undefined),
+        name: typeof t.name === "string" ? t.name : undefined,
+      },
+      rules,
+    );
+    if (!profile) return t;
+    if (!t.model && profile.model) t.model = profile.model;
+    if (!t.fallbackModels && profile.fallbackModels) t.fallbackModels = profile.fallbackModels;
+    if (!t.thinking && profile.thinking) t.thinking = profile.thinking;
+    if (profile.skills?.length) {
+      t.prompt = injectSkills(
+        typeof t.prompt === "string" ? t.prompt : undefined,
+        profile.skills,
+      );
+    }
+    return t;
+  });
+
+  return { ...p, tasks: nextTasks } as T;
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/hard-gate.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/hard-gate.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { getMode } from "./mode.ts";
-import { loadRules } from "./rules.ts";
+import { defaultRulesPath, loadRules } from "./rules.ts";
 import { getStagePolicy, readActiveStage, resolveStageName } from "./stage-policy.ts";
 import type {
   ExpertsMode,
@@ -18,6 +18,12 @@ export interface HardGateOptions {
   toolInput?: unknown;
   /** Optional Maestro stage override; falls back to activeStage / MAESTRO_STAGE. */
   stage?: string;
+  /**
+   * CV-01: who is calling the tool.
+   * - leader (default): hard-gate applies
+   * - expert: teammate child / relayed permission — always allow
+   */
+  caller?: "leader" | "expert";
 }
 
 const HEAVY_MUTATION_TOOLS = new Set(["write", "edit", "bash", "bash_bg"]);
@@ -29,7 +35,7 @@ const DEFAULT_LEADER_ALLOW_PATHS = [
   "**/outputs/**",
   ".workflow/**",
   "**/.workflow/**",
-  ".experts-mode.json",
+  // HV-04: do NOT allow writing .experts-mode.json (would flip mode off)
   "notes/**",
   "**/notes/**",
 ];
@@ -67,8 +73,14 @@ const DEFAULT_BASH_ALLOW_PREFIXES = [
 export function evaluateHardGate(toolName: string, opts: HardGateOptions = {}): GateResult {
   const cwd = opts.cwd ?? process.cwd();
   const mode = opts.mode ?? getMode(cwd);
-  const rules = opts.rules ?? loadRules();
+  // H1: always merge project .experts-rules.json from the tool cwd, not process.cwd().
+  const rules = opts.rules ?? loadRules(defaultRulesPath(), cwd);
   const name = normalizeToolName(toolName);
+
+  // CV-01: expert teammates must not be blocked by Lead discipline.
+  if (opts.caller === "expert") {
+    return { decision: "allow", reason: "expert caller — lead hard-gate skipped" };
+  }
 
   if (mode !== "experts") {
     return { decision: "allow", reason: "normal mode — no experts gate" };
@@ -127,10 +139,22 @@ export function buildRewriteSuggestion(
   toolName: string,
   toolInput: unknown,
   stage: string | undefined,
-  rules: ExpertsRules = loadRules(),
+  rules?: ExpertsRules,
   cwd = process.cwd(),
 ): RewriteSuggestion {
+  // H1: default rules merge project overlay from cwd.
+  const resolvedRules = rules ?? loadRules(defaultRulesPath(), cwd);
   const name = normalizeToolName(toolName);
+  return buildRewriteSuggestionWithRules(name, toolInput, stage, resolvedRules, cwd);
+}
+
+function buildRewriteSuggestionWithRules(
+  name: string,
+  toolInput: unknown,
+  stage: string | undefined,
+  rules: ExpertsRules,
+  cwd: string,
+): RewriteSuggestion {
   const stageKey = resolveStageName(stage, rules) || stage;
   const policy = stageKey ? getStagePolicy(stageKey, rules)?.policy : undefined;
   const primary = policy?.pipeline?.[0];
@@ -157,7 +181,7 @@ export function buildRewriteSuggestion(
     "Lead discipline rewrite: complete this work as an expert teammate.",
     intentBits.length ? `Context: ${intentBits.join("; ")}` : "",
     "Implement only the blocked leader action; return a concise RESULT with files touched and verification.",
-    "Do not hardcode model ids; role ≠ model.",
+    "Do not hardcode model ids; role != model.",
   ].filter(Boolean).join("\n");
 
   return {
@@ -170,6 +194,27 @@ export function buildRewriteSuggestion(
     pathHint,
     commandHint,
   };
+}
+
+/**
+ * H2: reject shell chaining / substitution that can bypass bash prefix allowlist.
+ * True means the command is unsafe for Leader allowlist even if prefix matches.
+ */
+export function hasDangerousShellMetachar(command: string): boolean {
+  const c = String(command || "");
+  if (!c) return false;
+  if (/[\r\n]/.test(c)) return true;
+  if (c.includes("&&") || c.includes("||")) return true;
+  if (c.includes(";")) return true;
+  if (c.includes("|")) return true;
+  if (c.includes("`")) return true;
+  if (c.includes("$(") || c.includes("${")) return true;
+  // HV-02: redirects can write arbitrary paths despite read-only prefixes
+  if (c.includes(">")) return true;
+  // inline code execution commonly used to bypass write gate
+  if (/(?:^|\s)-e(?:\s|$)/.test(c) || /(?:^|\s)--eval(?:\s|$)/.test(c)) return true;
+  if (/\bnode\s+-e\b/i.test(c) || /\bpython(?:3)?\s+-c\b/i.test(c)) return true;
+  return false;
 }
 
 export function formatDenyReason(toolName: string, rewrite: RewriteSuggestion): string {
@@ -231,16 +276,31 @@ function isLeaderAllowed(
   if (toolName === "bash" || toolName === "bash_bg") {
     const command = extractCommandHint(toolName, toolInput);
     if (!command) return false;
+    // H2: prefix allowlist must not accept chained / substituted commands.
+    if (hasDangerousShellMetachar(command)) return false;
     const prefixes = [
       ...(rules.hardGate?.bashAllowPrefixes || []),
       ...DEFAULT_BASH_ALLOW_PREFIXES,
     ];
     const normalized = command.replace(/^\s+/, "");
-    return prefixes.some((prefix) => {
-      const p = prefix.toLowerCase();
-      const c = normalized.toLowerCase();
-      return c === p.trim() || c.startsWith(p);
-    });
+    return prefixes.some((prefix) => bashPrefixMatches(normalized, prefix));
+  }
+  return false;
+}
+
+/** Prefix match with word boundary so "npm test" does not allow "npm testify". */
+export function bashPrefixMatches(command: string, prefix: string): boolean {
+  const c = command.replace(/^\s+/, "").toLowerCase();
+  const p = String(prefix || "").toLowerCase();
+  if (!p) return false;
+  const trimmed = p.trimEnd();
+  if (c === trimmed) return true;
+  if (c.startsWith(p)) {
+    // if prefix ends with whitespace, startsWith is enough
+    if (/\s$/.test(p)) return true;
+    // otherwise require end or whitespace after prefix (word boundary)
+    const rest = c.slice(trimmed.length);
+    return rest.length === 0 || /^\s/.test(rest);
   }
   return false;
 }

--- a/packages/pi-maestro-teammate/src/experts-mode/hard-gate.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/hard-gate.ts
@@ -1,0 +1,361 @@
+import path from "node:path";
+import { getMode } from "./mode.ts";
+import { loadRules } from "./rules.ts";
+import { getStagePolicy, readActiveStage, resolveStageName } from "./stage-policy.ts";
+import type {
+  ExpertsMode,
+  ExpertsRules,
+  GateDecision,
+  GateResult,
+  RewriteSuggestion,
+} from "./types.ts";
+
+export interface HardGateOptions {
+  mode?: ExpertsMode;
+  cwd?: string;
+  rules?: ExpertsRules;
+  /** Tool arguments (write path, bash command, …). */
+  toolInput?: unknown;
+  /** Optional Maestro stage override; falls back to activeStage / MAESTRO_STAGE. */
+  stage?: string;
+}
+
+const HEAVY_MUTATION_TOOLS = new Set(["write", "edit", "bash", "bash_bg"]);
+
+const DEFAULT_LEADER_ALLOW_PATHS = [
+  "report.md",
+  "**/report.md",
+  "outputs/**",
+  "**/outputs/**",
+  ".workflow/**",
+  "**/.workflow/**",
+  ".experts-mode.json",
+  "notes/**",
+  "**/notes/**",
+];
+
+const DEFAULT_BASH_ALLOW_PREFIXES = [
+  "maestro ",
+  "maestro\t",
+  "git status",
+  "git diff",
+  "git log",
+  "git show",
+  "git rev-parse",
+  "npm test",
+  "npm run test",
+  "node --test",
+  "node --experimental-transform-types --test",
+  "rg ",
+  "ls ",
+  "dir ",
+  "pwd",
+  "cat ",
+  "type ",
+  "head ",
+  "tail ",
+];
+
+/**
+ * P5 Lead discipline hard-gate for tool calls under Experts Mode.
+ *
+ * Defaults (default-rules): write/edit/bash → deny, with:
+ * - path allowlist for orchestration artifacts (report/outputs/.workflow/notes)
+ * - bash allowlist for maestro/git-read/test/search commands
+ * - deny reason always carries rewriteSuggestion → teammate + taskType
+ */
+export function evaluateHardGate(toolName: string, opts: HardGateOptions = {}): GateResult {
+  const cwd = opts.cwd ?? process.cwd();
+  const mode = opts.mode ?? getMode(cwd);
+  const rules = opts.rules ?? loadRules();
+  const name = normalizeToolName(toolName);
+
+  if (mode !== "experts") {
+    return { decision: "allow", reason: "normal mode — no experts gate" };
+  }
+
+  const table = rules.hardGate?.tools || {};
+  const fallback = rules.hardGate?.default || "allow";
+  let decision: GateDecision = (table[name] || fallback) as GateDecision;
+  if (decision !== "allow" && decision !== "ask" && decision !== "deny") {
+    decision = "allow";
+  }
+
+  const stage = resolveGateStage(opts.stage, cwd, rules);
+  const rewrite = buildRewriteSuggestion(name, opts.toolInput, stage, rules, cwd);
+
+  // Path / command allowlists only apply when the base decision is deny|ask.
+  if (decision === "deny" || decision === "ask") {
+    if (isLeaderAllowed(name, opts.toolInput, stage, rules, cwd)) {
+      return {
+        decision: "allow",
+        reason: `experts mode allows leader orchestration use of "${name}" (allowlist)`,
+        stage,
+        rewriteSuggestion: rewrite,
+      };
+    }
+  }
+
+  if (decision === "deny") {
+    return {
+      decision: "deny",
+      reason: formatDenyReason(name, rewrite),
+      stage,
+      rewriteSuggestion: rewrite,
+    };
+  }
+  if (decision === "ask") {
+    return {
+      decision: "ask",
+      reason: formatAskReason(name, rewrite),
+      stage,
+      rewriteSuggestion: rewrite,
+    };
+  }
+  return {
+    decision: "allow",
+    reason: `experts mode allows tool "${name}"`,
+    stage,
+  };
+}
+
+/**
+ * Build a teammate rewrite suggestion for a blocked heavy tool call.
+ * Pure helper — safe to call from adapters without re-evaluating the gate.
+ */
+export function buildRewriteSuggestion(
+  toolName: string,
+  toolInput: unknown,
+  stage: string | undefined,
+  rules: ExpertsRules = loadRules(),
+  cwd = process.cwd(),
+): RewriteSuggestion {
+  const name = normalizeToolName(toolName);
+  const stageKey = resolveStageName(stage, rules) || stage;
+  const policy = stageKey ? getStagePolicy(stageKey, rules)?.policy : undefined;
+  const primary = policy?.pipeline?.[0];
+  const taskType =
+    (primary?.taskType && String(primary.taskType))
+    || rules.defaultTaskType
+    || "development";
+  const agent =
+    (primary?.agent && String(primary.agent))
+    || rules.taskTypes?.[taskType]?.agent
+    || rules.defaultAgent
+    || "general-executor";
+
+  const pathHint = extractPathHint(name, toolInput, cwd);
+  const commandHint = extractCommandHint(name, toolInput);
+  const intentBits = [
+    stageKey ? `Maestro stage=${stageKey}` : null,
+    pathHint ? `path=${pathHint}` : null,
+    commandHint ? `command=${commandHint}` : null,
+    name ? `blocked_tool=${name}` : null,
+  ].filter(Boolean);
+
+  const prompt = [
+    "Lead discipline rewrite: complete this work as an expert teammate.",
+    intentBits.length ? `Context: ${intentBits.join("; ")}` : "",
+    "Implement only the blocked leader action; return a concise RESULT with files touched and verification.",
+    "Do not hardcode model ids; role ≠ model.",
+  ].filter(Boolean).join("\n");
+
+  return {
+    action: "teammate",
+    taskType,
+    agent,
+    stage: stageKey,
+    prompt,
+    blockedTool: name,
+    pathHint,
+    commandHint,
+  };
+}
+
+export function formatDenyReason(toolName: string, rewrite: RewriteSuggestion): string {
+  return [
+    `experts mode DENIES tool "${toolName}" for Leader — do not implement with ${toolName}.`,
+    `Rewrite: dispatch teammate with taskType=${rewrite.taskType} agent=${rewrite.agent}`
+      + (rewrite.stage ? ` stage=${rewrite.stage}` : "")
+      + ".",
+    rewrite.pathHint ? `Blocked path: ${rewrite.pathHint}.` : "",
+    rewrite.commandHint ? `Blocked command: ${rewrite.commandHint}.` : "",
+    "Example: teammate({ tasks:[{ prompt, taskType, agent, stage }], ... }) then wait/settle.",
+  ].filter(Boolean).join(" ");
+}
+
+export function formatAskReason(toolName: string, rewrite: RewriteSuggestion): string {
+  return [
+    `experts mode: tool "${toolName}" is heavy-side; prefer teammate+taskType or confirm.`,
+    `Suggested rewrite: taskType=${rewrite.taskType} agent=${rewrite.agent}`
+      + (rewrite.stage ? ` stage=${rewrite.stage}` : "")
+      + ".",
+  ].join(" ");
+}
+
+function resolveGateStage(
+  explicit: string | undefined,
+  cwd: string,
+  rules: ExpertsRules,
+): string | undefined {
+  if (explicit) return resolveStageName(explicit, rules) || explicit;
+  try {
+    const active = readActiveStage(cwd)?.stage;
+    if (active) return resolveStageName(active, rules) || active;
+  } catch {
+    // ignore
+  }
+  if (typeof process.env.MAESTRO_STAGE === "string" && process.env.MAESTRO_STAGE.trim()) {
+    return resolveStageName(process.env.MAESTRO_STAGE, rules) || process.env.MAESTRO_STAGE;
+  }
+  return undefined;
+}
+
+function normalizeToolName(toolName: string): string {
+  return String(toolName || "").trim();
+}
+
+function isLeaderAllowed(
+  toolName: string,
+  toolInput: unknown,
+  stage: string | undefined,
+  rules: ExpertsRules,
+  cwd: string,
+): boolean {
+  if (toolName === "write" || toolName === "edit") {
+    const filePath = extractPathHint(toolName, toolInput, cwd);
+    if (!filePath) return false;
+    const patterns = collectPathAllowlist(stage, rules);
+    return patterns.some((pattern) => matchPathPattern(filePath, pattern, cwd));
+  }
+  if (toolName === "bash" || toolName === "bash_bg") {
+    const command = extractCommandHint(toolName, toolInput);
+    if (!command) return false;
+    const prefixes = [
+      ...(rules.hardGate?.bashAllowPrefixes || []),
+      ...DEFAULT_BASH_ALLOW_PREFIXES,
+    ];
+    const normalized = command.replace(/^\s+/, "");
+    return prefixes.some((prefix) => {
+      const p = prefix.toLowerCase();
+      const c = normalized.toLowerCase();
+      return c === p.trim() || c.startsWith(p);
+    });
+  }
+  return false;
+}
+
+function collectPathAllowlist(stage: string | undefined, rules: ExpertsRules): string[] {
+  const fromRules = rules.hardGate?.leaderAllowPaths || [];
+  const fromStage = stage
+    ? (getStagePolicy(stage, rules)?.policy.leaderMayWrite || [])
+    : [];
+  return [...DEFAULT_LEADER_ALLOW_PATHS, ...fromRules, ...fromStage];
+}
+
+function extractPathHint(toolName: string, toolInput: unknown, cwd: string): string | undefined {
+  if (!toolInput || typeof toolInput !== "object") return undefined;
+  const input = toolInput as Record<string, unknown>;
+  const candidates = [
+    input.path,
+    input.file_path,
+    input.filePath,
+    input.filename,
+    input.target,
+  ];
+  // edit tools sometimes nest
+  if (input.file && typeof input.file === "object") {
+    const file = input.file as Record<string, unknown>;
+    candidates.push(file.path, file.file_path);
+  }
+  for (const value of candidates) {
+    if (typeof value === "string" && value.trim()) {
+      return normalizePathForMatch(value, cwd);
+    }
+  }
+  // Some hosts pass path as first positional-like field
+  if (toolName === "write" || toolName === "edit") {
+    for (const value of Object.values(input)) {
+      if (typeof value === "string" && looksLikePath(value)) {
+        return normalizePathForMatch(value, cwd);
+      }
+    }
+  }
+  return undefined;
+}
+
+function extractCommandHint(toolName: string, toolInput: unknown): string | undefined {
+  if (toolName !== "bash" && toolName !== "bash_bg") return undefined;
+  if (!toolInput || typeof toolInput !== "object") return undefined;
+  const input = toolInput as Record<string, unknown>;
+  for (const key of ["command", "cmd", "script", "bash"]) {
+    if (typeof input[key] === "string" && input[key].trim()) return String(input[key]).trim();
+  }
+  return undefined;
+}
+
+function looksLikePath(value: string): boolean {
+  return /[\\/]/.test(value) || /\.[a-z0-9]+$/i.test(value);
+}
+
+function normalizePathForMatch(filePath: string, cwd: string): string {
+  const resolved = path.isAbsolute(filePath) ? path.normalize(filePath) : path.normalize(path.join(cwd, filePath));
+  // Prefer project-relative POSIX-ish path for glob matching
+  const rel = path.relative(cwd, resolved);
+  const useRel = rel && !rel.startsWith("..") && !path.isAbsolute(rel) ? rel : resolved;
+  return useRel.split(path.sep).join("/");
+}
+
+/**
+ * Minimal glob matcher: supports ** and * segments, case-insensitive on win.
+ */
+export function matchPathPattern(filePath: string, pattern: string, cwd = process.cwd()): boolean {
+  const file = normalizePathForMatch(filePath, cwd).replace(/^\.\//, "");
+  const pat = pattern.replace(/\\/g, "/").replace(/^\.\//, "");
+  const fileNorm = process.platform === "win32" ? file.toLowerCase() : file;
+  const patNorm = process.platform === "win32" ? pat.toLowerCase() : pat;
+
+  // Exact or basename-only pattern like report.md
+  if (fileNorm === patNorm) return true;
+  if (!patNorm.includes("/") && fileNorm.endsWith("/" + patNorm)) return true;
+
+  const regex = globToRegExp(patNorm);
+  return regex.test(fileNorm);
+}
+
+function globToRegExp(glob: string): RegExp {
+  let re = "^";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*" && glob[i + 1] === "*") {
+      // ** optional slash
+      if (glob[i + 2] === "/") {
+        re += "(?:.*/)?";
+        i += 2;
+      } else {
+        re += ".*";
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "*") {
+      re += "[^/]*";
+      continue;
+    }
+    if (ch === "?") {
+      re += "[^/]";
+      continue;
+    }
+    if ("+.^${}()|[]\\".includes(ch)) {
+      re += "\\" + ch;
+      continue;
+    }
+    re += ch;
+  }
+  re += "$";
+  return new RegExp(re);
+}
+
+export function isHeavyMutationTool(toolName: string): boolean {
+  return HEAVY_MUTATION_TOOLS.has(normalizeToolName(toolName));
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/harvest-status.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/harvest-status.ts
@@ -1,0 +1,45 @@
+import type { KnowledgeHarvestSuggestion } from "./types.ts";
+import { getKnowledgeSuggestions } from "./knowledge-harvest.ts";
+
+/** Extension status key for cockpit footer + Maestro statusline. */
+export const EXPERTS_HARVEST_STATUS_KEY = "experts-harvest";
+
+/**
+ * Compact status text for pending experts knowledgeSuggestions.
+ * Empty string → clear the status segment.
+ *
+ * Formats:
+ * - 0 → ""
+ * - n → "HARVEST n"
+ * - with kinds → "HARVEST n · pitfall:1 trade-off:2" (short)
+ */
+export function formatExpertsHarvestStatus(
+  suggestions: readonly KnowledgeHarvestSuggestion[] | number,
+): string {
+  const list = typeof suggestions === "number" ? null : suggestions;
+  const count = typeof suggestions === "number" ? suggestions : suggestions.length;
+  if (count <= 0) return "";
+  if (!list || list.length === 0) return `HARVEST ${count}`;
+  const kinds = new Map<string, number>();
+  for (const s of list) {
+    kinds.set(s.kind, (kinds.get(s.kind) || 0) + 1);
+  }
+  const kindText = [...kinds.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([k, n]) => `${k}:${n}`)
+    .join(" ");
+  return kindText ? `HARVEST ${count} · ${kindText}` : `HARVEST ${count}`;
+}
+
+/** Read state file and format status for UI. */
+export function expertsHarvestStatusFromCwd(
+  cwd = process.cwd(),
+  statePath?: string,
+): string {
+  try {
+    return formatExpertsHarvestStatus(getKnowledgeSuggestions(cwd, statePath));
+  } catch {
+    return "";
+  }
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -5,8 +5,10 @@ export {
   defaultRulesPath,
   projectRulesPath,
   mergeRules,
+  mergeRosterMaps,
   PROJECT_RULES_FILENAME,
 } from "./rules.ts";
+export { writeJsonStateFile, readJsonStateFile } from "./state-io.ts";
 export { classifyIntent } from "./triage.ts";
 export { ensureExpertsDispatch } from "./dispatch.ts";
 export type { EnsureExpertsDispatchOptions } from "./dispatch.ts";
@@ -72,6 +74,8 @@ export {
   isHeavyMutationTool,
   formatDenyReason,
   formatAskReason,
+  hasDangerousShellMetachar,
+  bashPrefixMatches,
 } from "./hard-gate.ts";
 export type { HardGateOptions } from "./hard-gate.ts";
 export {

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -8,7 +8,13 @@ export {
   mergeRosterMaps,
   PROJECT_RULES_FILENAME,
 } from "./rules.ts";
-export { writeJsonStateFile, readJsonStateFile } from "./state-io.ts";
+export {
+  writeJsonStateFile,
+  readJsonStateFile,
+  withStateLock,
+  withStateLockSync,
+  mutateJsonStateFile,
+} from "./state-io.ts";
 export { classifyIntent } from "./triage.ts";
 export { ensureExpertsDispatch } from "./dispatch.ts";
 export type { EnsureExpertsDispatchOptions } from "./dispatch.ts";

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -1,0 +1,130 @@
+export { getMode, setMode, readState, resolveStatePath } from "./mode.ts";
+export {
+  loadRules,
+  clearRulesCache,
+  defaultRulesPath,
+  projectRulesPath,
+  mergeRules,
+  PROJECT_RULES_FILENAME,
+} from "./rules.ts";
+export { classifyIntent } from "./triage.ts";
+export { ensureExpertsDispatch } from "./dispatch.ts";
+export type { EnsureExpertsDispatchOptions } from "./dispatch.ts";
+export { recordLastDispatch, getStatus, buildCanvasSnapshot } from "./observe.ts";
+export type { ExpertsStatus } from "./observe.ts";
+export {
+  getRoster,
+  resolveRosterEntry,
+  agentForTaskTypeFromRoster,
+} from "./roster.ts";
+export {
+  getInFlight,
+  trackInFlight,
+  settleInFlight,
+  clearInFlight,
+} from "./inflight.ts";
+export {
+  harvestKnowledgeOnSettle,
+  buildStageCommand,
+  getKnowledgeSuggestions,
+  clearKnowledgeSuggestions,
+  assessKnowledgeCandidate,
+} from "./knowledge-harvest.ts";
+export {
+  EXPERTS_HARVEST_STATUS_KEY,
+  formatExpertsHarvestStatus,
+  expertsHarvestStatusFromCwd,
+} from "./harvest-status.ts";
+export {
+  depositHarvestToSelfEvolvePool,
+  harvestToSelfEvolveSignal,
+  selfEvolveOutputRoot,
+  suggestionsDirPath,
+  dailySuggestionFileName,
+} from "./self-evolve-deposit.ts";
+export type {
+  SelfEvolvePoolDepositResult,
+  DepositToSelfEvolvePoolOptions,
+} from "./self-evolve-deposit.ts";
+export {
+  evaluateHardGate,
+  buildRewriteSuggestion,
+  matchPathPattern,
+  isHeavyMutationTool,
+  formatDenyReason,
+  formatAskReason,
+} from "./hard-gate.ts";
+export type { HardGateOptions } from "./hard-gate.ts";
+export {
+  buildTurnReminder,
+  injectTurnReminder,
+  EXPERTS_REMINDER_START,
+  EXPERTS_REMINDER_END,
+} from "./prompt.ts";
+export type { TurnReminderOptions } from "./prompt.ts";
+export {
+  ORCHESTRATOR_DISCIPLINE_MARK,
+  buildOrchestratorDisciplineFragment,
+  buildViceLeadDispatchHint,
+  shouldSuggestViceLead,
+} from "./orchestrator-discipline.ts";
+export type { OrchestratorDisciplineOptions } from "./orchestrator-discipline.ts";
+export {
+  getLeaderWaiting,
+  setLeaderWaiting,
+  clearLeaderWaiting,
+  noteExpertsSettled,
+  buildWaitingFragment,
+  injectWaitingFragment,
+  EXPERTS_WAITING_START,
+  EXPERTS_WAITING_END,
+} from "./waiting.ts";
+export type { LeaderWaitingState } from "./waiting.ts";
+export { formatExpertResult, parseExpertResultAgentId } from "./result.ts";
+export type { ExpertResultInput } from "./result.ts";
+export {
+  resolveStageExpertsPlan,
+  resolveStageName,
+  getStagePolicy,
+  primaryStageAssignment,
+  readActiveStage,
+  writeActiveStage,
+  DEFAULT_STAGE_ALIASES,
+} from "./stage-policy.ts";
+export type {
+  ResolveStageExpertsPlanOptions,
+  ActiveStageState,
+} from "./stage-policy.ts";
+export {
+  resolveMaestroStageFromWorkspace,
+  syncActiveStageFromMaestro,
+  formatStageBirthPacket,
+  setMaestroStageEnvIfUnset,
+} from "./maestro-stage.ts";
+export type {
+  MaestroStageInfo,
+  ResolveMaestroStageOptions,
+  SyncMaestroStageOptions,
+} from "./maestro-stage.ts";
+export type {
+  ExpertsMode,
+  ExpertsTaskType,
+  TriageResult,
+  DispatchRecord,
+  TeammateParamsLike,
+  TeammateTaskLike,
+  GateDecision,
+  GateResult,
+  RewriteSuggestion,
+  StagePolicy,
+  StagePipelineStep,
+  StageExpertsPlan,
+  ExpertsRules,
+  RosterEntry,
+  InFlightExpert,
+  ExpertsCanvasSnapshot,
+  KnowledgeHarvestSuggestion,
+  KnowledgeStageCommand,
+  SettleHarvestInput,
+  SettleHarvestResult,
+} from "./types.ts";

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -13,6 +13,10 @@ export type { EnsureExpertsDispatchOptions } from "./dispatch.ts";
 export { recordLastDispatch, getStatus, buildCanvasSnapshot } from "./observe.ts";
 export type { ExpertsStatus } from "./observe.ts";
 export {
+  formatExpertsStatusPanel,
+  formatExpertsStatusPanelFromStatus,
+} from "./status-panel.ts";
+export {
   getRoster,
   resolveRosterEntry,
   agentForTaskTypeFromRoster,

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -28,6 +28,15 @@ export {
   agentForTaskTypeFromRoster,
 } from "./roster.ts";
 export {
+  resolveChannel,
+  resolveModelRef,
+  resolveExpertProfile,
+  applyExpertProfiles,
+  EXPERTS_SKILLS_START,
+  EXPERTS_SKILLS_END,
+} from "./expert-profile.ts";
+export type { ExpertProfileResolved } from "./expert-profile.ts";
+export {
   getInFlight,
   trackInFlight,
   settleInFlight,

--- a/packages/pi-maestro-teammate/src/experts-mode/index.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/index.ts
@@ -15,7 +15,13 @@ export type { ExpertsStatus } from "./observe.ts";
 export {
   formatExpertsStatusPanel,
   formatExpertsStatusPanelFromStatus,
+  formatExpertsRosterPanelFromStatus,
+  formatExpertsWaitingPanelFromStatus,
+  formatExpertsHarvestPanelFromStatus,
+  formatExpertsPanelFromStatus,
+  formatExpertsPanel,
 } from "./status-panel.ts";
+export type { ExpertsPanelView } from "./status-panel.ts";
 export {
   getRoster,
   resolveRosterEntry,

--- a/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getMode, resolveStatePath } from "./mode.ts";
+import type { InFlightExpert } from "./types.ts";
+
+function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) return {};
+    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
+  const file = resolveStatePath(cwd, statePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+function parseList(raw: Record<string, unknown>): InFlightExpert[] {
+  if (!Array.isArray(raw.inFlight)) return [];
+  const out: InFlightExpert[] = [];
+  for (const item of raw.inFlight) {
+    if (!item || typeof item !== "object") continue;
+    const o = item as Record<string, unknown>;
+    const id = typeof o.id === "string" ? o.id : "";
+    if (!id) continue;
+    out.push({
+      id,
+      agent: typeof o.agent === "string" ? o.agent : undefined,
+      taskType: typeof o.taskType === "string" ? o.taskType : undefined,
+      name: typeof o.name === "string" ? o.name : undefined,
+      stage: typeof o.stage === "string" ? o.stage : undefined,
+      at: typeof o.at === "string" ? o.at : new Date().toISOString(),
+      correlationId: typeof o.correlationId === "string" ? o.correlationId : undefined,
+    });
+  }
+  return out;
+}
+
+/** Read current in-flight experts (P6 observability). */
+export function getInFlight(cwd = process.cwd(), statePath?: string): InFlightExpert[] {
+  return parseList(readRaw(cwd, statePath));
+}
+
+/** Append or replace in-flight entries by id. */
+export function trackInFlight(
+  entries: Array<Partial<InFlightExpert> & { id?: string; name?: string; agent?: string }>,
+  opts: { cwd?: string; statePath?: string; stage?: string } = {},
+): InFlightExpert[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const prev = readRaw(cwd, opts.statePath);
+  const list = parseList(prev);
+  const now = new Date().toISOString();
+  for (const entry of entries) {
+    const id = String(entry.id || entry.correlationId || entry.name || entry.agent || "").trim();
+    if (!id) continue;
+    const nextEntry: InFlightExpert = {
+      id,
+      agent: entry.agent ? String(entry.agent) : undefined,
+      taskType: entry.taskType ? String(entry.taskType) : undefined,
+      name: entry.name ? String(entry.name) : undefined,
+      stage: entry.stage ? String(entry.stage) : opts.stage,
+      at: now,
+      correlationId: entry.correlationId ? String(entry.correlationId) : undefined,
+    };
+    const idx = list.findIndex((e) => e.id === id);
+    if (idx >= 0) list[idx] = { ...list[idx], ...nextEntry, at: now };
+    else list.push(nextEntry);
+  }
+  const next = {
+    ...prev,
+    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
+    inFlight: list,
+    updatedAt: now,
+  };
+  writeRaw(cwd, next, opts.statePath);
+  return list;
+}
+
+/**
+ * Remove settled experts from in-flight.
+ * Match by id, correlationId, name, or agent (first match).
+ */
+export function settleInFlight(
+  keys: string | string[],
+  opts: { cwd?: string; statePath?: string } = {},
+): InFlightExpert[] {
+  const cwd = opts.cwd ?? process.cwd();
+  const want = new Set(
+    (Array.isArray(keys) ? keys : [keys]).map((k) => String(k || "").trim()).filter(Boolean),
+  );
+  if (want.size === 0) return getInFlight(cwd, opts.statePath);
+  const prev = readRaw(cwd, opts.statePath);
+  const list = parseList(prev).filter((e) => {
+    if (want.has(e.id)) return false;
+    if (e.correlationId && want.has(e.correlationId)) return false;
+    if (e.name && want.has(e.name)) return false;
+    if (e.agent && want.has(e.agent)) return false;
+    return true;
+  });
+  writeRaw(cwd, {
+    ...prev,
+    inFlight: list,
+    updatedAt: new Date().toISOString(),
+  }, opts.statePath);
+  return list;
+}
+
+export function clearInFlight(
+  cwd = process.cwd(),
+  opts: { statePath?: string } = {},
+): InFlightExpert[] {
+  const prev = readRaw(cwd, opts.statePath);
+  writeRaw(cwd, {
+    ...prev,
+    inFlight: [],
+    updatedAt: new Date().toISOString(),
+  }, opts.statePath);
+  return [];
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
@@ -1,22 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getMode, resolveStatePath } from "./mode.ts";
+import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
 import type { InFlightExpert } from "./types.ts";
 
 function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
-  const file = resolveStatePath(cwd, statePath);
-  try {
-    if (!fs.existsSync(file)) return {};
-    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
+  return readJsonStateFile(resolveStatePath(cwd, statePath));
 }
 
 function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
-  const file = resolveStatePath(cwd, statePath);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  writeJsonStateFile(resolveStatePath(cwd, statePath), next);
 }
 
 function parseList(raw: Record<string, unknown>): InFlightExpert[] {

--- a/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/inflight.ts
@@ -1,16 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
 import { getMode, resolveStatePath } from "./mode.ts";
-import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
+import { mutateJsonStateFile, readJsonStateFile } from "./state-io.ts";
 import type { InFlightExpert } from "./types.ts";
-
-function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
-  return readJsonStateFile(resolveStatePath(cwd, statePath));
-}
-
-function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
-  writeJsonStateFile(resolveStatePath(cwd, statePath), next);
-}
 
 function parseList(raw: Record<string, unknown>): InFlightExpert[] {
   if (!Array.isArray(raw.inFlight)) return [];
@@ -35,7 +25,7 @@ function parseList(raw: Record<string, unknown>): InFlightExpert[] {
 
 /** Read current in-flight experts (P6 observability). */
 export function getInFlight(cwd = process.cwd(), statePath?: string): InFlightExpert[] {
-  return parseList(readRaw(cwd, statePath));
+  return parseList(readJsonStateFile(resolveStatePath(cwd, statePath)));
 }
 
 /** Append or replace in-flight entries by id. */
@@ -44,38 +34,41 @@ export function trackInFlight(
   opts: { cwd?: string; statePath?: string; stage?: string } = {},
 ): InFlightExpert[] {
   const cwd = opts.cwd ?? process.cwd();
-  const prev = readRaw(cwd, opts.statePath);
-  const list = parseList(prev);
+  const file = resolveStatePath(cwd, opts.statePath);
   const now = new Date().toISOString();
-  for (const entry of entries) {
-    const id = String(entry.id || entry.correlationId || entry.name || entry.agent || "").trim();
-    if (!id) continue;
-    const nextEntry: InFlightExpert = {
-      id,
-      agent: entry.agent ? String(entry.agent) : undefined,
-      taskType: entry.taskType ? String(entry.taskType) : undefined,
-      name: entry.name ? String(entry.name) : undefined,
-      stage: entry.stage ? String(entry.stage) : opts.stage,
-      at: now,
-      correlationId: entry.correlationId ? String(entry.correlationId) : undefined,
+  const next = mutateJsonStateFile(file, (prev) => {
+    const list = parseList(prev);
+    for (const entry of entries) {
+      const id = String(entry.id || entry.correlationId || entry.name || entry.agent || "").trim();
+      if (!id) continue;
+      const nextEntry: InFlightExpert = {
+        id,
+        agent: entry.agent ? String(entry.agent) : undefined,
+        taskType: entry.taskType ? String(entry.taskType) : undefined,
+        name: entry.name ? String(entry.name) : undefined,
+        stage: entry.stage ? String(entry.stage) : opts.stage,
+        at: now,
+        correlationId: entry.correlationId ? String(entry.correlationId) : undefined,
+      };
+      const idx = list.findIndex((e) => e.id === id);
+      if (idx >= 0) list[idx] = { ...list[idx], ...nextEntry, at: now };
+      else list.push(nextEntry);
+    }
+    return {
+      ...prev,
+      mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
+      inFlight: list,
+      updatedAt: now,
     };
-    const idx = list.findIndex((e) => e.id === id);
-    if (idx >= 0) list[idx] = { ...list[idx], ...nextEntry, at: now };
-    else list.push(nextEntry);
-  }
-  const next = {
-    ...prev,
-    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
-    inFlight: list,
-    updatedAt: now,
-  };
-  writeRaw(cwd, next, opts.statePath);
-  return list;
+  });
+  return parseList(next);
 }
 
 /**
- * Remove settled experts from in-flight.
- * Match by id, correlationId, name, or agent (first match).
+ * Remove settled experts from in-flight (MV-04).
+ * 1) Exact match: id / correlationId / name (all matching entries).
+ * 2) Agent fallback: only for keys not satisfied by exact match, remove at most
+ *    ONE entry per agent key (avoids wiping parallel same-agent tasks).
  */
 export function settleInFlight(
   keys: string | string[],
@@ -86,31 +79,57 @@ export function settleInFlight(
     (Array.isArray(keys) ? keys : [keys]).map((k) => String(k || "").trim()).filter(Boolean),
   );
   if (want.size === 0) return getInFlight(cwd, opts.statePath);
-  const prev = readRaw(cwd, opts.statePath);
-  const list = parseList(prev).filter((e) => {
-    if (want.has(e.id)) return false;
-    if (e.correlationId && want.has(e.correlationId)) return false;
-    if (e.name && want.has(e.name)) return false;
-    if (e.agent && want.has(e.agent)) return false;
-    return true;
+  const file = resolveStatePath(cwd, opts.statePath);
+  const next = mutateJsonStateFile(file, (prev) => {
+    const list = parseList(prev);
+    const removeIdx = new Set<number>();
+    const unmatched = new Set(want);
+
+    for (let i = 0; i < list.length; i++) {
+      const e = list[i]!;
+      if (want.has(e.id)) {
+        removeIdx.add(i);
+        unmatched.delete(e.id);
+        continue;
+      }
+      if (e.correlationId && want.has(e.correlationId)) {
+        removeIdx.add(i);
+        unmatched.delete(e.correlationId);
+        continue;
+      }
+      if (e.name && want.has(e.name)) {
+        removeIdx.add(i);
+        unmatched.delete(e.name);
+        continue;
+      }
+    }
+
+    for (let i = 0; i < list.length; i++) {
+      if (removeIdx.has(i)) continue;
+      const e = list[i]!;
+      if (e.agent && unmatched.has(e.agent)) {
+        removeIdx.add(i);
+        unmatched.delete(e.agent);
+      }
+    }
+
+    return {
+      ...prev,
+      inFlight: list.filter((_, i) => !removeIdx.has(i)),
+      updatedAt: new Date().toISOString(),
+    };
   });
-  writeRaw(cwd, {
-    ...prev,
-    inFlight: list,
-    updatedAt: new Date().toISOString(),
-  }, opts.statePath);
-  return list;
+  return parseList(next);
 }
 
 export function clearInFlight(
   cwd = process.cwd(),
   opts: { statePath?: string } = {},
 ): InFlightExpert[] {
-  const prev = readRaw(cwd, opts.statePath);
-  writeRaw(cwd, {
+  mutateJsonStateFile(resolveStatePath(cwd, opts.statePath), (prev) => ({
     ...prev,
     inFlight: [],
     updatedAt: new Date().toISOString(),
-  }, opts.statePath);
+  }));
   return [];
 }

--- a/packages/pi-maestro-teammate/src/experts-mode/knowledge-harvest.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/knowledge-harvest.ts
@@ -1,0 +1,458 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { getMode, resolveStatePath } from "./mode.ts";
+import { loadRules } from "./rules.ts";
+import { depositHarvestToSelfEvolvePool } from "./self-evolve-deposit.ts";
+import type {
+  ExpertsRules,
+  KnowledgeHarvestSuggestion,
+  KnowledgeStageCommand,
+  SettleHarvestInput,
+  SettleHarvestResult,
+} from "./types.ts";
+
+const DEFAULT_MAX_SUGGESTIONS = 5;
+const DEFAULT_MIN_BODY = 40;
+const DEFAULT_MAX_BODY = 4000;
+const STATE_KEY = "knowledgeSuggestions";
+const SEEN_KEY = "knowledgeSuggestionFingerprints";
+
+const RAW_TRACE_PATTERNS = [
+  /tool_call/i,
+  /function_call/i,
+  /```json\s*\{\s*"type"\s*:\s*"tool"/i,
+  /\[experts-mode\]/i,
+  /bash-bg-complete/i,
+  /teammate-complete/i,
+  /Observation:/i,
+  /<\/?tool/i,
+];
+
+const LOW_VALUE_PATTERNS = [
+  /^(ok|done|yes|no|thanks|你好|谢谢|继续)\.?$/i,
+  /lorem ipsum/i,
+  /TODO:\s*fill/i,
+  /^test\s*only$/i,
+];
+
+const SIGNAL_HINTS: Array<{ re: RegExp; kind: KnowledgeHarvestSuggestion["kind"]; weight: number }> = [
+  { re: /when doing|when you|pitfall|watch out|注意|陷阱|不要|avoid\b|gotcha/i, kind: "pitfall", weight: 3 },
+  { re: /failed|failure|error|bug|regression|失败|报错|根因|root cause/i, kind: "failure-lesson", weight: 3 },
+  { re: /trade-?off|权衡|prefer X|instead of|rather than|取舍/i, kind: "trade-off", weight: 2 },
+  { re: /must|should always|constraint|禁止|必须|invariant|prescriptive/i, kind: "constraint", weight: 2 },
+  { re: /lesson|learned|经验|复盘|knowhow|recipe|pattern/i, kind: "knowhow", weight: 1 },
+];
+
+/**
+ * P7: harvest knowledge *suggestions* from expert settle content.
+ * - Suggest only (default); never auto-promote.
+ * - Quality bar rejects raw traces / trivial ops.
+ * - Fingerprint dedup against prior suggestions in .experts-mode.json.
+ */
+export function harvestKnowledgeOnSettle(
+  input: SettleHarvestInput,
+  opts: {
+    cwd?: string;
+    statePath?: string;
+    rules?: ExpertsRules;
+    record?: boolean;
+    maxSuggestions?: number;
+  } = {},
+): SettleHarvestResult {
+  const cwd = opts.cwd ?? process.cwd();
+  const rules = opts.rules ?? loadRules();
+  const settleCfg = rules.settle ?? {};
+  const enabled = settleCfg.knowledgeHarvest !== false;
+  const max = opts.maxSuggestions
+    ?? settleCfg.maxSuggestions
+    ?? DEFAULT_MAX_SUGGESTIONS;
+
+  if (!enabled) {
+    return {
+      suggestions: [],
+      skipped: [{ reason: "knowledge harvest disabled in rules.settle" }],
+      stageCommands: [],
+    };
+  }
+
+  if (getMode(cwd, opts.statePath) !== "experts" && input.force !== true) {
+    return {
+      suggestions: [],
+      skipped: [{ reason: "normal mode — harvest skipped (set force:true to override)" }],
+      stageCommands: [],
+    };
+  }
+
+  const bodies = collectBodies(input);
+  const seen = new Set(readSeenFingerprints(cwd, opts.statePath));
+  const suggestions: KnowledgeHarvestSuggestion[] = [];
+  const skipped: Array<{ reason: string; preview?: string }> = [];
+
+  for (const body of bodies) {
+    const candidates = extractCandidateBlocks(body, input);
+    for (const cand of candidates) {
+      const quality = scoreCandidate(cand.text);
+      if (!quality.ok) {
+        skipped.push({ reason: quality.reason, preview: cand.text.slice(0, 80) });
+        continue;
+      }
+      const fingerprint = fingerprintText(cand.text);
+      if (seen.has(fingerprint)) {
+        skipped.push({ reason: "duplicate fingerprint", preview: cand.text.slice(0, 80) });
+        continue;
+      }
+      seen.add(fingerprint);
+      const title = cand.title || deriveTitle(cand.text, quality.kind);
+      const suggestion: KnowledgeHarvestSuggestion = {
+        id: `kh-${fingerprint.slice(0, 12)}`,
+        target: "knowhow",
+        kind: quality.kind,
+        title,
+        content: truncateBody(cand.text, settleCfg.maxBodyChars ?? DEFAULT_MAX_BODY),
+        fingerprint,
+        score: quality.score,
+        agentId: input.agentId,
+        taskType: input.taskType,
+        stage: input.stage,
+        sessionId: input.sessionId,
+        runId: input.runId,
+        evidence: input.evidenceRefs ?? [],
+        at: new Date().toISOString(),
+        source: "experts-settle",
+      };
+      suggestions.push(suggestion);
+      if (suggestions.length >= max) break;
+    }
+    if (suggestions.length >= max) break;
+  }
+
+  // Prefer higher score
+  suggestions.sort((a, b) => b.score - a.score);
+  const limited = suggestions.slice(0, max);
+
+  const stageCommands = limited.map((s) => buildStageCommand(s, input));
+
+  if (opts.record !== false && limited.length > 0) {
+    try {
+      persistSuggestions(cwd, limited, [...seen], opts.statePath);
+    } catch {
+      // bookkeeping must not break settle
+    }
+  }
+
+  // P7b: optional autoStage → self-evolve pending suggestions pool (never promote).
+  let poolDeposit: SettleHarvestResult["poolDeposit"];
+  if (settleCfg.autoStage === true && limited.length > 0) {
+    try {
+      const deposit = depositHarvestToSelfEvolvePool(limited, {
+        cwd,
+        sessionId: input.sessionId,
+        runId: input.runId,
+        outputRoot: typeof settleCfg.selfEvolveOutputRoot === "string"
+          ? settleCfg.selfEvolveOutputRoot
+          : undefined,
+      });
+      poolDeposit = {
+        written: deposit.written,
+        skipped: deposit.skipped,
+        filePath: deposit.filePath,
+        ids: deposit.ids,
+      };
+      if (deposit.errors.length) {
+        for (const err of deposit.errors) {
+          skipped.push({ reason: `self-evolve pool: ${err}` });
+        }
+      }
+    } catch (error) {
+      skipped.push({
+        reason: `self-evolve pool failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  return { suggestions: limited, skipped, stageCommands, poolDeposit };
+}
+
+/** Build a copy-pasteable `maestro knowledge stage` command (never auto-runs). */
+export function buildStageCommand(
+  suggestion: KnowledgeHarvestSuggestion,
+  input: Pick<SettleHarvestInput, "sessionId" | "runId" | "evidenceRefs"> = {},
+): KnowledgeStageCommand {
+  const sessionId = suggestion.sessionId || input.sessionId;
+  const runId = suggestion.runId || input.runId;
+  const args = [
+    "knowledge",
+    "stage",
+    suggestion.target,
+    suggestion.title,
+  ];
+  // content via stdin/file is preferred by CLI quality bar; we return content separately.
+  const flags: string[] = ["--json"];
+  if (runId) flags.push("--run", runId);
+  else if (sessionId) flags.push("--session", sessionId);
+  if (suggestion.evidence.length) {
+    flags.push("--evidence", suggestion.evidence.join(","));
+  }
+  flags.push("--category", suggestion.kind);
+
+  const shell = [
+    "maestro",
+    "knowledge",
+    "stage",
+    suggestion.target,
+    JSON.stringify(suggestion.title),
+    "--content-file",
+    "-",
+    ...(runId ? ["--run", runId] : sessionId ? ["--session", sessionId] : []),
+    ...(suggestion.evidence.length ? ["--evidence", suggestion.evidence.join(",")] : []),
+    "--category",
+    suggestion.kind,
+    "--json",
+  ].join(" ");
+
+  return {
+    argv: ["maestro", ...args, ...flags],
+    shell,
+    content: suggestion.content,
+    suggestionId: suggestion.id,
+  };
+}
+
+export function getKnowledgeSuggestions(
+  cwd = process.cwd(),
+  statePath?: string,
+): KnowledgeHarvestSuggestion[] {
+  const raw = readRaw(cwd, statePath);
+  if (!Array.isArray(raw[STATE_KEY])) return [];
+  return (raw[STATE_KEY] as unknown[])
+    .map((item) => normalizeSuggestion(item))
+    .filter((x): x is KnowledgeHarvestSuggestion => Boolean(x));
+}
+
+export function clearKnowledgeSuggestions(
+  cwd = process.cwd(),
+  opts: { statePath?: string; keepFingerprints?: boolean } = {},
+): void {
+  const prev = readRaw(cwd, opts.statePath);
+  const next: Record<string, unknown> = {
+    ...prev,
+    [STATE_KEY]: [],
+    updatedAt: new Date().toISOString(),
+  };
+  if (!opts.keepFingerprints) next[SEEN_KEY] = [];
+  writeRaw(cwd, next, opts.statePath);
+}
+
+/** Pure quality gate used by harvest + tests. */
+export function assessKnowledgeCandidate(text: string): {
+  ok: boolean;
+  reason: string;
+  kind: KnowledgeHarvestSuggestion["kind"];
+  score: number;
+} {
+  return scoreCandidate(String(text || ""));
+}
+
+function collectBodies(input: SettleHarvestInput): string[] {
+  const out: string[] = [];
+  if (typeof input.content === "string" && input.content.trim()) out.push(input.content);
+  if (Array.isArray(input.contents)) {
+    for (const c of input.contents) {
+      if (typeof c === "string" && c.trim()) out.push(c);
+    }
+  }
+  return out;
+}
+
+function extractCandidateBlocks(
+  body: string,
+  input: SettleHarvestInput,
+): Array<{ title?: string; text: string }> {
+  const text = stripResultEnvelope(body).trim();
+  if (!text) return [];
+
+  // Explicit markers from expert output
+  const marked: Array<{ title?: string; text: string }> = [];
+  const blockRe =
+    /(?:^|\n)\s*(?:KNOWLEDGE|KNOWHOW|PITFALL|LESSON|FAILURE|CONSTRAINT|TRADE-?OFF)\s*[:：]\s*(.+?)(?=\n\s*(?:KNOWLEDGE|KNOWHOW|PITFALL|LESSON|FAILURE|CONSTRAINT|TRADE-?OFF)\s*[:：]|\n---|\n#|$)/gis;
+  let m: RegExpExecArray | null;
+  while ((m = blockRe.exec(text)) !== null) {
+    const chunk = m[1]?.trim();
+    if (chunk) marked.push({ text: chunk });
+  }
+  if (marked.length) return marked;
+
+  // fenced knowhow blocks
+  const fenceRe = /```(?:knowhow|knowledge|pitfall)\s*([\s\S]*?)```/gi;
+  while ((m = fenceRe.exec(text)) !== null) {
+    const chunk = m[1]?.trim();
+    if (chunk) marked.push({ text: chunk });
+  }
+  if (marked.length) return marked;
+
+  // Heuristic: split into paragraphs; keep substantial ones with signal
+  const paras = text
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const scored = paras
+    .map((p) => ({ text: p, q: scoreCandidate(p) }))
+    .filter((x) => x.q.ok)
+    .sort((a, b) => b.q.score - a.q.score)
+    .slice(0, 3)
+    .map((x) => ({ text: x.text }));
+
+  if (scored.length) return scored;
+
+  // Last resort: whole body if it itself passes quality
+  if (scoreCandidate(text).ok) {
+    return [{
+      title: input.titleHint,
+      text,
+    }];
+  }
+  return [];
+}
+
+function scoreCandidate(text: string): {
+  ok: boolean;
+  reason: string;
+  kind: KnowledgeHarvestSuggestion["kind"];
+  score: number;
+} {
+  const t = text.trim();
+  if (t.length < DEFAULT_MIN_BODY) {
+    return { ok: false, reason: `too short (<${DEFAULT_MIN_BODY})`, kind: "knowhow", score: 0 };
+  }
+  if (RAW_TRACE_PATTERNS.some((re) => re.test(t))) {
+    return { ok: false, reason: "raw tool/trace content rejected", kind: "knowhow", score: 0 };
+  }
+  if (LOW_VALUE_PATTERNS.some((re) => re.test(t))) {
+    return { ok: false, reason: "trivial / low-value content", kind: "knowhow", score: 0 };
+  }
+  // Reject pure code dumps without prose
+  const codeRatio = (t.match(/[{};=<>]/g) || []).length / Math.max(t.length, 1);
+  if (codeRatio > 0.12 && !SIGNAL_HINTS.some((h) => h.re.test(t))) {
+    return { ok: false, reason: "code-heavy without lesson signal", kind: "knowhow", score: 0 };
+  }
+
+  let score = 1;
+  let kind: KnowledgeHarvestSuggestion["kind"] = "knowhow";
+  for (const hint of SIGNAL_HINTS) {
+    if (hint.re.test(t)) {
+      score += hint.weight;
+      if (hint.weight >= 2 || kind === "knowhow") kind = hint.kind;
+    }
+  }
+  // Prefer actionable structure: "when X … because Y"
+  if (/\bwhen\b.+\b(because|since|否则|因为)\b/i.test(t) || /当.+时.+(因为|否则)/.test(t)) {
+    score += 2;
+  }
+  if (score < 2) {
+    return { ok: false, reason: "no durable lesson signal", kind: "knowhow", score };
+  }
+  return { ok: true, reason: "ok", kind, score };
+}
+
+function stripResultEnvelope(body: string): string {
+  const idx = body.search(/---\s*RESULT\s*---/i);
+  if (idx >= 0) {
+    return body.slice(idx).replace(/---\s*RESULT\s*---/i, "").trim();
+  }
+  return body;
+}
+
+function deriveTitle(text: string, kind: string): string {
+  const first = text.split(/\n/)[0]?.trim() || kind;
+  const cleaned = first.replace(/^[#*\-\d.)\s]+/, "").slice(0, 80);
+  return cleaned || `experts-${kind}`;
+}
+
+function truncateBody(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 20).trimEnd()}\n…[truncated]`;
+}
+
+function fingerprintText(text: string): string {
+  const norm = text
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, "")
+    .trim();
+  return createHash("sha256").update(norm).digest("hex");
+}
+
+function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) return {};
+    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
+  const file = resolveStatePath(cwd, statePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+function readSeenFingerprints(cwd: string, statePath?: string): string[] {
+  const raw = readRaw(cwd, statePath);
+  if (!Array.isArray(raw[SEEN_KEY])) return [];
+  return (raw[SEEN_KEY] as unknown[]).map(String).filter(Boolean);
+}
+
+function persistSuggestions(
+  cwd: string,
+  suggestions: KnowledgeHarvestSuggestion[],
+  seen: string[],
+  statePath?: string,
+): void {
+  const prev = readRaw(cwd, statePath);
+  const existing = Array.isArray(prev[STATE_KEY])
+    ? (prev[STATE_KEY] as unknown[]).map(normalizeSuggestion).filter(Boolean) as KnowledgeHarvestSuggestion[]
+    : [];
+  const byFp = new Map<string, KnowledgeHarvestSuggestion>();
+  for (const s of existing) byFp.set(s.fingerprint, s);
+  for (const s of suggestions) byFp.set(s.fingerprint, s);
+  const merged = [...byFp.values()]
+    .sort((a, b) => (a.at < b.at ? 1 : -1))
+    .slice(0, DEFAULT_MAX_SUGGESTIONS * 4);
+  writeRaw(cwd, {
+    ...prev,
+    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, statePath),
+    [STATE_KEY]: merged,
+    [SEEN_KEY]: seen.slice(-200),
+    updatedAt: new Date().toISOString(),
+  }, statePath);
+}
+
+function normalizeSuggestion(item: unknown): KnowledgeHarvestSuggestion | null {
+  if (!item || typeof item !== "object") return null;
+  const o = item as Record<string, unknown>;
+  if (typeof o.id !== "string" || typeof o.content !== "string" || typeof o.fingerprint !== "string") {
+    return null;
+  }
+  return {
+    id: o.id,
+    target: o.target === "spec" ? "spec" : "knowhow",
+    kind: (["pitfall", "failure-lesson", "trade-off", "constraint", "knowhow"].includes(String(o.kind))
+      ? String(o.kind)
+      : "knowhow") as KnowledgeHarvestSuggestion["kind"],
+    title: String(o.title || o.id),
+    content: String(o.content),
+    fingerprint: String(o.fingerprint),
+    score: typeof o.score === "number" ? o.score : 0,
+    agentId: typeof o.agentId === "string" ? o.agentId : undefined,
+    taskType: typeof o.taskType === "string" ? o.taskType : undefined,
+    stage: typeof o.stage === "string" ? o.stage : undefined,
+    sessionId: typeof o.sessionId === "string" ? o.sessionId : undefined,
+    runId: typeof o.runId === "string" ? o.runId : undefined,
+    evidence: Array.isArray(o.evidence) ? o.evidence.map(String) : [],
+    at: typeof o.at === "string" ? o.at : new Date().toISOString(),
+    source: "experts-settle",
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/maestro-stage.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/maestro-stage.ts
@@ -1,0 +1,320 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getMode } from "./mode.ts";
+import { loadRules } from "./rules.ts";
+import {
+  resolveStageExpertsPlan,
+  resolveStageName,
+  writeActiveStage,
+} from "./stage-policy.ts";
+import type { ExpertsRules, StageExpertsPlan } from "./types.ts";
+
+/**
+ * P4.1 — Maestro stage auto-injection.
+ *
+ * The Maestro session.json is the single source of truth for the current
+ * chain step (orchestration.chain[].stage + active_run_id). These helpers
+ * read that file (never write it) so Leaders no longer need to pass
+ * stage/MAESTRO_STAGE by hand: the stage is auto-detected from the running
+ * session and injected into ensureExpertsDispatch / the turn reminder.
+ */
+
+const ACTIVE_STEP_STATUSES = new Set(["running", "active", "in_progress"]);
+const SEALED_STEP_STATUSES = new Set([
+  "done",
+  "completed",
+  "sealed",
+  "skipped",
+  "failed",
+  "cancelled",
+  "aborted",
+  "blocked",
+]);
+
+/** Lightweight shape of a Maestro session.json (read-only, best-effort). */
+interface SessionFileLike {
+  session_id?: unknown;
+  intent?: unknown;
+  status?: unknown;
+  active_run_id?: unknown;
+  lifecycle?: { sealed_at?: unknown };
+  orchestration?: {
+    chain?: Array<{
+      step_id?: unknown;
+      command?: unknown;
+      status?: unknown;
+      run_id?: unknown;
+      stage?: unknown;
+    }>;
+  };
+}
+
+export interface MaestroStageInfo {
+  /** Session id owning the current step. */
+  sessionId: string;
+  /** active_run_id (or the matched step's run_id). */
+  runId?: string;
+  /** Normalized stage policy key (aliases resolved, e.g. maestro-execute → execute). */
+  stage: string;
+  /** Raw step id when known. */
+  stepId?: string;
+  /** Raw chain command (e.g. execute / maestro-execute). */
+  command?: string;
+  /** Session intent text when present. */
+  intent?: string;
+  /** Where the stage came from: MAESTRO_SESSION_ID env or workspace scan. */
+  source: "env" | "workspace";
+}
+
+export interface ResolveMaestroStageOptions {
+  /** Rules for resolveStageName alias mapping (defaults to loadRules()). */
+  rules?: ExpertsRules;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+
+function nonEmptyStr(v: unknown): boolean {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+type ChainStep = {
+  step_id?: unknown;
+  command?: unknown;
+  status?: unknown;
+  run_id?: unknown;
+  stage?: unknown;
+};
+
+function sessionChain(session: SessionFileLike): ChainStep[] {
+  const chain = session?.orchestration?.chain;
+  return Array.isArray(chain) ? (chain as ChainStep[]) : [];
+}
+
+function readSessionFile(file: string): SessionFileLike | null {
+  try {
+    if (!fs.existsSync(file)) return null;
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as SessionFileLike;
+    if (!raw || typeof raw !== "object") return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function hasActiveStep(session: SessionFileLike): boolean {
+  const chain = sessionChain(session);
+  if (chain.length === 0) return false;
+  if (nonEmptyStr(session.active_run_id)) {
+    if (chain.some((s) => s.run_id === session.active_run_id)) return true;
+  }
+  return chain.some((s) =>
+    ACTIVE_STEP_STATUSES.has(String(s.status || "").toLowerCase()),
+  );
+}
+
+function hasSealedAt(session: SessionFileLike): boolean {
+  return nonEmptyStr(session.lifecycle?.sealed_at);
+}
+
+function selectActiveStep(session: SessionFileLike): ChainStep | undefined {
+  const chain = sessionChain(session);
+  if (chain.length === 0) return undefined;
+  // 1. step matching active_run_id
+  if (nonEmptyStr(session.active_run_id)) {
+    const byRun = chain.find((s) => s.run_id === session.active_run_id);
+    if (byRun) return byRun;
+  }
+  // 2. first step with an active status
+  const active = chain.find((s) =>
+    ACTIVE_STEP_STATUSES.has(String(s.status || "").toLowerCase()),
+  );
+  if (active) return active;
+  // 3. first non-sealed step
+  return chain.find((s) =>
+    !SEALED_STEP_STATUSES.has(String(s.status || "").toLowerCase()),
+  );
+}
+
+interface ScannedSession {
+  session: SessionFileLike;
+  sessionId: string;
+  mtime: number;
+}
+
+function scanSessions(sessionsRoot: string): ScannedSession | undefined {
+  if (!fs.existsSync(sessionsRoot)) return undefined;
+  let entries;
+  try {
+    entries = fs.readdirSync(sessionsRoot, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  const parsed: ScannedSession[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const sessionId = entry.name;
+    const file = path.join(sessionsRoot, sessionId, "session.json");
+    const session = readSessionFile(file);
+    if (!session) continue;
+    let mtime = 0;
+    try {
+      mtime = fs.statSync(file).mtimeMs;
+    } catch {
+      // keep mtime 0
+    }
+    parsed.push({ session, sessionId, mtime });
+  }
+  if (parsed.length === 0) return undefined;
+  const byMtime = (a: ScannedSession, b: ScannedSession): number => b.mtime - a.mtime;
+  // Tier 1: running session with an active_run_id (latest wins).
+  const tier1 = parsed
+    .filter((p) => {
+      const status = String(p.session.status || "").toLowerCase();
+      return status === "running" && nonEmptyStr(p.session.active_run_id);
+    })
+    .sort(byMtime);
+  if (tier1[0]) return tier1[0];
+  // Tier 2: latest running-or-unsealed session that still has an active step.
+  const tier2 = parsed
+    .filter((p) => {
+      const status = String(p.session.status || "").toLowerCase();
+      if (status !== "running" && hasSealedAt(p.session)) return false;
+      return hasActiveStep(p.session);
+    })
+    .sort(byMtime);
+  return tier2[0] ?? undefined;
+}
+
+/**
+ * Resolve the current Maestro stage from the workspace without throwing.
+ *
+ * 1. MAESTRO_SESSION_ID env wins when its session.json exists;
+ * 2. otherwise scan the .workflow/sessions directory for the latest
+ *    running session.json (with active_run_id) or latest non-sealed
+ *    session with an active step;
+ * 3. stage = step.stage || step.command, normalized via resolveStageName.
+ *
+ * Returns null (never throws) when nothing usable is found.
+ */
+export function resolveMaestroStageFromWorkspace(
+  cwd = process.cwd(),
+  opts: ResolveMaestroStageOptions = {},
+): MaestroStageInfo | null {
+  try {
+    const rules = opts.rules ?? loadRules();
+    const sessionsRoot = path.resolve(cwd, ".workflow", "sessions");
+    const envSessionId = nonEmptyStr(process.env.MAESTRO_SESSION_ID)
+      ? String(process.env.MAESTRO_SESSION_ID)
+      : undefined;
+
+    let scanned: ScannedSession | undefined;
+    if (envSessionId) {
+      const session = readSessionFile(path.join(sessionsRoot, envSessionId, "session.json"));
+      if (session) scanned = { session, sessionId: envSessionId, mtime: 0 };
+    }
+    if (!scanned) scanned = scanSessions(sessionsRoot);
+    if (!scanned) return null;
+
+    const step = selectActiveStep(scanned.session);
+    if (!step) return null;
+    const stageRaw = str(step.stage) || str(step.command) || "";
+    const stage = resolveStageName(stageRaw, rules) || stageRaw || "unknown";
+    return {
+      sessionId: scanned.sessionId,
+      runId: str(scanned.session.active_run_id) || str(step.run_id) || undefined,
+      stage,
+      stepId: str(step.step_id) || undefined,
+      command: str(step.command) || undefined,
+      intent: str(scanned.session.intent) || undefined,
+      source: envSessionId ? "env" : "workspace",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort: set process.env.MAESTRO_STAGE when it is not already set.
+ * Never overrides an explicit stage.
+ */
+export function setMaestroStageEnvIfUnset(stage: string): void {
+  try {
+    if (!nonEmptyStr(process.env.MAESTRO_STAGE)) process.env.MAESTRO_STAGE = stage;
+  } catch {
+    // env mutation must never break dispatch/context injection
+  }
+}
+
+export interface SyncMaestroStageOptions {
+  /** Mode gate: only writes activeStage under experts. Defaults to getMode(cwd). */
+  mode?: "experts" | "normal";
+  rules?: ExpertsRules;
+  /** When false, process.env.MAESTRO_STAGE is left untouched. Default true. */
+  setEnv?: boolean;
+}
+
+/**
+ * Auto-inject the Maestro stage into experts state:
+ * resolve stage from session.json → writeActiveStage (with source
+ * "maestro-session" + session/run ids) → return the stage experts plan.
+ *
+ * No-ops (returns null) when no running session is found; never throws.
+ */
+export function syncActiveStageFromMaestro(
+  cwd = process.cwd(),
+  opts: SyncMaestroStageOptions = {},
+): StageExpertsPlan | null {
+  const mode = opts.mode ?? getMode(cwd);
+  const found = resolveMaestroStageFromWorkspace(cwd, { rules: opts.rules });
+  if (!found) return null;
+  if (mode === "experts" && opts.setEnv !== false) {
+    setMaestroStageEnvIfUnset(found.stage);
+  }
+  const plan = resolveStageExpertsPlan(found.stage, found.intent || "", {
+    cwd,
+    rules: opts.rules,
+    record: mode === "experts",
+  });
+  if (mode === "experts") {
+    try {
+      writeActiveStage(cwd, {
+        stage: plan.stage,
+        source: "maestro-session",
+        sessionId: found.sessionId,
+        runId: found.runId,
+        taskTypes: plan.tasks.map((t) => String(t.taskType || "")),
+        agents: plan.tasks.map((t) => String(t.agent || "")),
+        intentPreview: String(found.intent || "").slice(0, 160),
+        at: new Date().toISOString(),
+      });
+    } catch {
+      // state persistence must not break stage sync
+    }
+  }
+  return plan;
+}
+
+/**
+ * Short leader-facing birth packet for the stage: stage, source, pipeline
+ * taskTypes, agents, and the first lines of leaderInstructions. Designed to
+ * be passed as stageHint into buildTurnReminder / injectTurnReminder.
+ */
+export function formatStageBirthPacket(plan: StageExpertsPlan): string {
+  const taskTypes =
+    (plan.tasks?.map((t) => String(t.taskType || "")).filter(Boolean) || []).join(" → ") || "—";
+  const agents =
+    (plan.tasks?.map((t) => String(t.agent || "")).filter(Boolean) || []).join(", ") || "—";
+  const leaderFirstLines = String(plan.leaderInstructions || "")
+    .split("\n")
+    .filter(Boolean)
+    .slice(0, 3)
+    .join("\n");
+  return [
+    `Stage birth: "${plan.stage}" (mode=${plan.mode}, source=${plan.source}).`,
+    `Pipeline: ${taskTypes}.`,
+    `Agents: ${agents}.`,
+    leaderFirstLines,
+  ].filter(Boolean).join("\n");
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/mode.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/mode.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ExpertsMode } from "./types.ts";
+
+export function resolveStatePath(cwd = process.cwd(), explicitPath?: string): string {
+  if (explicitPath) return path.resolve(explicitPath);
+  if (process.env.EXPERTS_MODE_STATE) return path.resolve(process.env.EXPERTS_MODE_STATE);
+  return path.resolve(cwd, ".experts-mode.json");
+}
+
+export function getMode(cwd = process.cwd(), statePath?: string): ExpertsMode {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) return "normal";
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as { mode?: string };
+    return raw?.mode === "experts" ? "experts" : "normal";
+  } catch {
+    return "normal";
+  }
+}
+
+export function setMode(mode: ExpertsMode, cwd = process.cwd(), statePath?: string): Record<string, unknown> {
+  if (mode !== "normal" && mode !== "experts") {
+    throw new Error(`Invalid mode: ${mode}. Expected normal|experts`);
+  }
+  const file = resolveStatePath(cwd, statePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  let prev: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(file)) prev = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    prev = {};
+  }
+  const next = {
+    ...prev,
+    mode,
+    updatedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  return next;
+}
+
+export function readState(cwd = process.cwd(), statePath?: string): {
+  mode: ExpertsMode;
+  path: string;
+  updatedAt?: string | null;
+  lastDispatch?: unknown;
+} {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) {
+      return { mode: "normal", path: file, lastDispatch: null };
+    }
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as {
+      mode?: string;
+      updatedAt?: string;
+      lastDispatch?: unknown;
+    };
+    return {
+      mode: raw?.mode === "experts" ? "experts" : "normal",
+      path: file,
+      updatedAt: raw?.updatedAt ?? null,
+      lastDispatch: raw?.lastDispatch ?? null,
+    };
+  } catch {
+    return { mode: "normal", path: file, lastDispatch: null };
+  }
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/mode.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/mode.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
+import { mutateJsonStateFile, readJsonStateFile } from "./state-io.ts";
 import type { ExpertsMode } from "./types.ts";
 
 export function resolveStatePath(cwd = process.cwd(), explicitPath?: string): string {
@@ -25,14 +25,11 @@ export function setMode(mode: ExpertsMode, cwd = process.cwd(), statePath?: stri
     throw new Error(`Invalid mode: ${mode}. Expected normal|experts`);
   }
   const file = resolveStatePath(cwd, statePath);
-  const prev = readJsonStateFile(file);
-  const next = {
+  return mutateJsonStateFile(file, (prev) => ({
     ...prev,
     mode,
     updatedAt: new Date().toISOString(),
-  };
-  writeJsonStateFile(file, next);
-  return next;
+  }));
 }
 
 export function readState(cwd = process.cwd(), statePath?: string): {

--- a/packages/pi-maestro-teammate/src/experts-mode/mode.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/mode.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
 import type { ExpertsMode } from "./types.ts";
 
 export function resolveStatePath(cwd = process.cwd(), explicitPath?: string): string {
@@ -12,7 +13,7 @@ export function getMode(cwd = process.cwd(), statePath?: string): ExpertsMode {
   const file = resolveStatePath(cwd, statePath);
   try {
     if (!fs.existsSync(file)) return "normal";
-    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as { mode?: string };
+    const raw = readJsonStateFile(file) as { mode?: string };
     return raw?.mode === "experts" ? "experts" : "normal";
   } catch {
     return "normal";
@@ -24,19 +25,13 @@ export function setMode(mode: ExpertsMode, cwd = process.cwd(), statePath?: stri
     throw new Error(`Invalid mode: ${mode}. Expected normal|experts`);
   }
   const file = resolveStatePath(cwd, statePath);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  let prev: Record<string, unknown> = {};
-  try {
-    if (fs.existsSync(file)) prev = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
-  } catch {
-    prev = {};
-  }
+  const prev = readJsonStateFile(file);
   const next = {
     ...prev,
     mode,
     updatedAt: new Date().toISOString(),
   };
-  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  writeJsonStateFile(file, next);
   return next;
 }
 
@@ -51,7 +46,7 @@ export function readState(cwd = process.cwd(), statePath?: string): {
     if (!fs.existsSync(file)) {
       return { mode: "normal", path: file, lastDispatch: null };
     }
-    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as {
+    const raw = readJsonStateFile(file) as {
       mode?: string;
       updatedAt?: string;
       lastDispatch?: unknown;

--- a/packages/pi-maestro-teammate/src/experts-mode/observe.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/observe.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getInFlight } from "./inflight.ts";
+import { getKnowledgeSuggestions } from "./knowledge-harvest.ts";
+import { getMode, readState, resolveStatePath } from "./mode.ts";
+import { getRoster } from "./roster.ts";
+import { loadRules } from "./rules.ts";
+import { readActiveStage } from "./stage-policy.ts";
+import { getLeaderWaiting } from "./waiting.ts";
+import type {
+  DispatchRecord,
+  ExpertsCanvasSnapshot,
+  ExpertsMode,
+  InFlightExpert,
+  KnowledgeHarvestSuggestion,
+  RosterEntry,
+} from "./types.ts";
+
+export function recordLastDispatch(
+  record: DispatchRecord,
+  cwd = process.cwd(),
+  statePath?: string,
+): DispatchRecord {
+  const file = resolveStatePath(cwd, statePath);
+  let prev: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(file)) prev = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    prev = {};
+  }
+  const mode = prev.mode === "experts" || prev.mode === "normal"
+    ? prev.mode
+    : getMode(cwd, statePath);
+  const next = {
+    ...prev,
+    mode,
+    lastDispatch: record,
+    updatedAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  return record;
+}
+
+export interface ExpertsStatus {
+  mode: string;
+  path: string;
+  updatedAt: string | null;
+  lastDispatch: unknown;
+  leaderWaiting: boolean;
+  leaderWaitingCount: number;
+  leaderWaitingAgentIds: string[];
+  /** P4: last resolved Maestro stage policy snapshot. */
+  activeStage: ReturnType<typeof readActiveStage>;
+  /** P6: project experts roster (role → agent → default taskType). */
+  roster: RosterEntry[];
+  /** P6: in-flight expert units (names / correlation ids when known). */
+  inFlight: InFlightExpert[];
+  /** P7: pending knowhow suggestions from settle harvest (not promoted). */
+  knowledgeSuggestions: KnowledgeHarvestSuggestion[];
+}
+
+export function getStatus(cwd = process.cwd(), statePath?: string): ExpertsStatus {
+  const state = readState(cwd, statePath);
+  const waiting = getLeaderWaiting(cwd, statePath);
+  const rules = loadRules();
+  return {
+    mode: state.mode,
+    path: state.path,
+    updatedAt: state.updatedAt ?? null,
+    lastDispatch: state.lastDispatch ?? null,
+    leaderWaiting: waiting.leaderWaiting,
+    leaderWaitingCount: waiting.activeCount,
+    leaderWaitingAgentIds: waiting.lastAgentIds,
+    activeStage: readActiveStage(cwd, statePath),
+    roster: getRoster(rules),
+    inFlight: getInFlight(cwd, statePath),
+    knowledgeSuggestions: getKnowledgeSuggestions(cwd, statePath),
+  };
+}
+
+/**
+ * P6: lightweight JSON snapshot for cockpit / external observers.
+ * Not a full Canvas UI — schema only.
+ */
+export function buildCanvasSnapshot(
+  cwd = process.cwd(),
+  statePath?: string,
+): ExpertsCanvasSnapshot {
+  const status = getStatus(cwd, statePath);
+  const mode = (status.mode === "experts" || status.mode === "normal"
+    ? status.mode
+    : "normal") as ExpertsMode;
+  const last = (status.lastDispatch && typeof status.lastDispatch === "object"
+    ? status.lastDispatch
+    : null) as DispatchRecord | null;
+  return {
+    schema: "experts-canvas/1.0",
+    mode,
+    updatedAt: new Date().toISOString(),
+    activeStage: status.activeStage?.stage ?? null,
+    leaderWaiting: status.leaderWaiting,
+    leaderWaitingCount: status.leaderWaitingCount,
+    inFlight: status.inFlight,
+    lastDispatch: last,
+    roster: status.roster.map((r) => ({
+      id: r.id,
+      agent: r.agent,
+      defaultTaskType: r.defaultTaskType,
+      label: r.label,
+      enabled: r.enabled,
+    })),
+    knowledgeSuggestions: status.knowledgeSuggestions.map((s) => ({
+      id: s.id,
+      kind: s.kind,
+      title: s.title,
+      score: s.score,
+      fingerprint: s.fingerprint,
+    })),
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/observe.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/observe.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { getInFlight } from "./inflight.ts";
 import { getKnowledgeSuggestions } from "./knowledge-harvest.ts";
 import { getMode, readState, resolveStatePath } from "./mode.ts";
+import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
 import { getRoster } from "./roster.ts";
 import { loadRules } from "./rules.ts";
 import { readActiveStage } from "./stage-policy.ts";
@@ -37,8 +38,7 @@ export function recordLastDispatch(
     lastDispatch: record,
     updatedAt: new Date().toISOString(),
   };
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  writeJsonStateFile(file, next);
   return record;
 }
 

--- a/packages/pi-maestro-teammate/src/experts-mode/observe.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/observe.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs";
-import path from "node:path";
 import { getInFlight } from "./inflight.ts";
 import { getKnowledgeSuggestions } from "./knowledge-harvest.ts";
 import { getMode, readState, resolveStatePath } from "./mode.ts";
-import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
+import { mutateJsonStateFile } from "./state-io.ts";
 import { getRoster } from "./roster.ts";
 import { loadRules } from "./rules.ts";
 import { readActiveStage } from "./stage-policy.ts";
@@ -23,22 +21,17 @@ export function recordLastDispatch(
   statePath?: string,
 ): DispatchRecord {
   const file = resolveStatePath(cwd, statePath);
-  let prev: Record<string, unknown> = {};
-  try {
-    if (fs.existsSync(file)) prev = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
-  } catch {
-    prev = {};
-  }
-  const mode = prev.mode === "experts" || prev.mode === "normal"
-    ? prev.mode
-    : getMode(cwd, statePath);
-  const next = {
-    ...prev,
-    mode,
-    lastDispatch: record,
-    updatedAt: new Date().toISOString(),
-  };
-  writeJsonStateFile(file, next);
+  mutateJsonStateFile(file, (prev) => {
+    const mode = prev.mode === "experts" || prev.mode === "normal"
+      ? prev.mode
+      : getMode(cwd, statePath);
+    return {
+      ...prev,
+      mode,
+      lastDispatch: record,
+      updatedAt: new Date().toISOString(),
+    };
+  });
   return record;
 }
 

--- a/packages/pi-maestro-teammate/src/experts-mode/orchestrator-discipline.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/orchestrator-discipline.ts
@@ -1,0 +1,93 @@
+import type { ExpertsRules, TeammateTaskLike } from "./types.ts";
+
+/**
+ * P5.1 — Orchestrator discipline for Experts Mode.
+ *
+ * Reinforces the /maestro run-loop discipline in the per-turn reminder:
+ * the Leader only owns session/run lifecycle + teammate dispatch +
+ * synthesis, never business code. For multi-step stage pipelines the
+ * workflow agent may be suggested as optional vice-lead (decompose +
+ * dispatch DAG), while the Lead keeps session done/check/seal.
+ */
+
+/** Stable marker for the discipline fragment (used by tests + extension). */
+export const ORCHESTRATOR_DISCIPLINE_MARK = "Orchestrator discipline (P5.1)";
+
+export interface OrchestratorDisciplineOptions {
+  stage?: string;
+  /** taskTypes from active stage plan / pipeline */
+  taskTypes?: string[];
+  /** agents from plan */
+  agents?: string[];
+  /**
+   * Explicit vice-lead control: true forces guidance, false suppresses it.
+   * Undefined → rules.orchestrator.viceLead (default true) + multi-step check.
+   */
+  viceLead?: boolean;
+  /** optional project flag from rules */
+  rules?: ExpertsRules;
+}
+
+/**
+ * True when rules.orchestrator.viceLead !== false AND the pipeline is
+ * multi-step (>=2 taskTypes or >=2 agents) or force is set.
+ */
+export function shouldSuggestViceLead(opts: {
+  taskTypes?: string[];
+  agents?: string[];
+  rules?: ExpertsRules;
+  force?: boolean;
+}): boolean {
+  if (opts.rules?.orchestrator?.viceLead === false) return false;
+  const taskTypes = opts.taskTypes ?? [];
+  const agents = opts.agents ?? [];
+  const multiStep = taskTypes.length >= 2 || agents.length >= 2;
+  return opts.force === true || multiStep;
+}
+
+/** Compact multi-line fragment (no HTML wrapper), <12 lines. */
+export function buildOrchestratorDisciplineFragment(
+  opts: OrchestratorDisciplineOptions = {},
+): string {
+  const lines = [
+    `${ORCHESTRATOR_DISCIPLINE_MARK}: Lead only maestro session/run lifecycle + teammate dispatch + synthesize RESULT into report/outputs.`,
+    "NEVER implement business code yourself — rewrite as teammate+taskType (P5 hard gate).",
+    "Prefer automatic continuation when authority=automatic (session next/done loop).",
+    "Artifacts only: report.md, outputs/**, .workflow/**, notes/**.",
+  ];
+  const viceLead =
+    opts.viceLead === false
+      ? false
+      : shouldSuggestViceLead({
+        taskTypes: opts.taskTypes,
+        agents: opts.agents,
+        rules: opts.rules,
+        force: opts.viceLead === true,
+      });
+  if (viceLead) {
+    lines.push(
+      "Multi-step pipeline: optionally dispatch agent=workflow taskType=planning as vice-lead to decompose/dispatch DAG; Lead still owns session done/check/seal.",
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Optional helper: sample task shape for the workflow vice-lead.
+ * Role-based only (agent + taskType + prompt text); never a model id.
+ */
+export function buildViceLeadDispatchHint(
+  stage?: string,
+  intent?: string,
+): TeammateTaskLike {
+  return {
+    agent: "workflow",
+    taskType: "planning",
+    name: "vice-lead",
+    prompt: [
+      `Act as vice-lead for stage "${stage || "current"}".`,
+      intent ? `Intent: ${intent}` : "",
+      "Decompose the stage into a dependency-aware teammate DAG and dispatch it; Lead keeps session done/check/seal.",
+    ].filter(Boolean).join("\n"),
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/prompt.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/prompt.ts
@@ -1,0 +1,91 @@
+import { getMode } from "./mode.ts";
+import { buildOrchestratorDisciplineFragment } from "./orchestrator-discipline.ts";
+import type { ExpertsMode, ExpertsRules } from "./types.ts";
+
+export const EXPERTS_REMINDER_START = "<!-- experts-mode-reminder:start -->";
+export const EXPERTS_REMINDER_END = "<!-- experts-mode-reminder:end -->";
+
+export interface TurnReminderOptions {
+  stage?: string;
+  stageHint?: string;
+  /** P5.1: taskTypes from the active stage plan/pipeline (vice-lead hint). */
+  taskTypes?: string[];
+  /** P5.1: agents from the active stage plan. */
+  agents?: string[];
+  /** P5.1: project rules; orchestrator.disciplineReminder/viceLead consulted. */
+  rules?: ExpertsRules;
+  /** P5.1: explicit switch for the discipline fragment (default true). */
+  discipline?: boolean;
+}
+
+/**
+ * Qoder-like per-turn hard prompt (system_reminder analogue).
+ * Only meaningful when mode=experts; empty string in normal.
+ */
+export function buildTurnReminder(
+  mode: ExpertsMode = "experts",
+  opts: TurnReminderOptions = {},
+): string {
+  if (mode !== "experts") return "";
+  const stageLine = opts.stage
+    ? `Current Maestro stage: "${opts.stage}". Prefer resolveStageExpertsPlan / ensureExpertsDispatch({ stage }) so stagePolicies fill taskType before keyword triage.`
+    : "When executing a Maestro chain step, pass stage=analyze|plan|execute|review|test|debug into ensureExpertsDispatch so stagePolicies apply.";
+  const extra = opts.stageHint ? opts.stageHint : "";
+  const discipline =
+    opts.discipline !== false && opts.rules?.orchestrator?.disciplineReminder !== false
+      ? buildOrchestratorDisciplineFragment({
+        stage: opts.stage,
+        taskTypes: opts.taskTypes,
+        agents: opts.agents,
+        rules: opts.rules,
+      })
+      : "";
+  return [
+    EXPERTS_REMINDER_START,
+    "<experts_mode_reminder>",
+    "Experts Mode is ON. You are the Leader (orchestrator).",
+    stageLine,
+    "For any non-trivial work: dispatch teammate with an explicit taskType (explore|analysis|debug|planning|development|review|testing|verification).",
+    "Do NOT hardcode model ids — routing applies models from taskType via teammate-models.",
+    "Prefer agent/role for capability profile (explorer, general-executor, reviewer, …); never use role name as a model id.",
+    "While experts are running: wait for completion (observe/wait or completion notification) before synthesizing; do not package the heavy work yourself with write/edit/bash.",
+    "Lead discipline (P5): business write/edit/bash are DENIED for the Leader. Rewrite as teammate+taskType. Orchestration paths only: report.md, outputs/**, .workflow/**, notes/**; bash allowlist: maestro/git-read/tests.",
+    "When summarizing an expert result, keep agentId/name and a clear RESULT body.",
+    extra,
+    discipline,
+    "</experts_mode_reminder>",
+    EXPERTS_REMINDER_END,
+  ].filter(Boolean).join("\n");
+}
+
+/**
+ * Inject or replace the experts reminder block in a system prompt.
+ */
+export function injectTurnReminder(
+  systemPrompt: string,
+  opts: { mode?: ExpertsMode; cwd?: string } & TurnReminderOptions = {},
+): string {
+  const mode = opts.mode ?? getMode(opts.cwd ?? process.cwd());
+  const block = buildTurnReminder(mode, {
+    stage: opts.stage,
+    stageHint: opts.stageHint,
+    taskTypes: opts.taskTypes,
+    agents: opts.agents,
+    rules: opts.rules,
+    discipline: opts.discipline,
+  });
+  if (!block) {
+    // Strip prior block if mode flipped off
+    const start = systemPrompt.indexOf(EXPERTS_REMINDER_START);
+    if (start < 0) return systemPrompt;
+    const end = systemPrompt.indexOf(EXPERTS_REMINDER_END, start);
+    if (end < 0) return systemPrompt.slice(0, start).trimEnd();
+    return `${systemPrompt.slice(0, start).trimEnd()}${systemPrompt.slice(end + EXPERTS_REMINDER_END.length)}`.trimEnd();
+  }
+
+  const start = systemPrompt.indexOf(EXPERTS_REMINDER_START);
+  if (start < 0) return `${systemPrompt.trimEnd()}\n\n${block}`;
+  const end = systemPrompt.indexOf(EXPERTS_REMINDER_END, start);
+  if (end < 0) return `${systemPrompt.slice(0, start).trimEnd()}\n\n${block}`;
+  return `${systemPrompt.slice(0, start).trimEnd()}\n\n${block}${systemPrompt.slice(end + EXPERTS_REMINDER_END.length)}`;
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/result.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/result.ts
@@ -1,0 +1,48 @@
+/**
+ * Qoder-like fixed completion envelope for expert/teammate results.
+ * Pure formatter — callers opt in; does not rewrite all tool paths by default.
+ */
+
+export interface ExpertResultInput {
+  agentId: string;
+  agentName?: string;
+  content: string;
+  exitCode?: number;
+  taskType?: string;
+  /** When true, skip double-wrapping if content already has RESULT header */
+  skipIfPresent?: boolean;
+}
+
+export function formatExpertResult(input: ExpertResultInput): string {
+  const agentId = String(input.agentId || "unknown");
+  const name = input.agentName ? String(input.agentName) : undefined;
+  const body = String(input.content ?? "").trimEnd();
+
+  if (input.skipIfPresent !== false && /---\s*RESULT\s*---/i.test(body)) {
+    return body.endsWith("\n") ? body : `${body}\n`;
+  }
+
+  const who = name
+    ? `Agent ${name} has completed.`
+    : "Expert has completed.";
+  const lines = [
+    who,
+    "No need to reply to this envelope.",
+    `agentId: ${agentId} (internal ID — do not invent a different one)`,
+  ];
+  if (input.taskType) lines.push(`taskType: ${input.taskType}`);
+  if (typeof input.exitCode === "number") lines.push(`exitCode: ${input.exitCode}`);
+  lines.push("outputContent:");
+  lines.push("--- RESULT ---");
+  lines.push(body || "(no output)");
+  if (!body.endsWith("\n") && body.length > 0) {
+    /* already trimmed */
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/** Parse agentId from an envelope if present. */
+export function parseExpertResultAgentId(text: string): string | null {
+  const m = String(text).match(/agentId:\s*([^\s(]+)/i);
+  return m?.[1] ?? null;
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/roster.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/roster.ts
@@ -3,12 +3,13 @@ import type { ExpertsRules, RosterEntry } from "./types.ts";
 
 /**
  * P6: resolve the project experts roster.
- * Prefer explicit rules.roster; fall back to taskTypes → agent mapping.
- * Never assigns models (role ≠ model).
+ * Prefer explicit rules.roster (+ expertProfiles overlay); fall back to taskTypes.
+ * Role name ≠ model id — optional model/channel/skills are config mappings only.
  */
 export function getRoster(rules: ExpertsRules = loadRules()): RosterEntry[] {
   const fromConfig = rosterFromConfig(rules);
-  if (fromConfig.length > 0) return fromConfig;
+  const merged = mergeExpertProfiles(fromConfig, rules);
+  if (merged.length > 0) return merged;
   return rosterFromTaskTypes(rules);
 }
 
@@ -41,30 +42,84 @@ export function agentForTaskTypeFromRoster(
   return rules.taskTypes?.[taskType]?.agent || rules.defaultAgent || "general";
 }
 
+function parseRosterValue(
+  key: string,
+  value: Omit<RosterEntry, "id"> & { id?: string },
+  rules: ExpertsRules,
+): RosterEntry | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const agent = String(value.agent || key).trim();
+  const defaultTaskType = String(
+    value.defaultTaskType || rules.defaultTaskType || "development",
+  ).trim();
+  if (!agent || !defaultTaskType) return undefined;
+  const fallbackModels = Array.isArray(value.fallbackModels)
+    ? value.fallbackModels.map(String).map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  const skills = Array.isArray(value.skills)
+    ? value.skills.map(String).map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  return {
+    id: String(value.id || key).trim() || key,
+    agent,
+    defaultTaskType,
+    label: value.label ? String(value.label) : undefined,
+    capabilities: Array.isArray(value.capabilities)
+      ? value.capabilities.map(String)
+      : undefined,
+    tools: Array.isArray(value.tools) ? value.tools.map(String) : undefined,
+    enabled: value.enabled === false ? false : true,
+    model: value.model ? String(value.model).trim() : undefined,
+    fallbackModels: fallbackModels?.length ? fallbackModels : undefined,
+    thinking: value.thinking ? String(value.thinking).trim() : undefined,
+    channel: value.channel ? String(value.channel).trim() : undefined,
+    skills: skills?.length ? skills : undefined,
+  };
+}
+
 function rosterFromConfig(rules: ExpertsRules): RosterEntry[] {
   const raw = rules.roster;
   if (!raw || typeof raw !== "object") return [];
   const out: RosterEntry[] = [];
   for (const [key, value] of Object.entries(raw)) {
-    if (!value || typeof value !== "object") continue;
-    const agent = String(value.agent || key).trim();
-    const defaultTaskType = String(
-      value.defaultTaskType || rules.defaultTaskType || "development",
-    ).trim();
-    if (!agent || !defaultTaskType) continue;
-    out.push({
-      id: String(value.id || key).trim() || key,
-      agent,
-      defaultTaskType,
-      label: value.label ? String(value.label) : undefined,
-      capabilities: Array.isArray(value.capabilities)
-        ? value.capabilities.map(String)
-        : undefined,
-      tools: Array.isArray(value.tools) ? value.tools.map(String) : undefined,
-      enabled: value.enabled === false ? false : true,
-    });
+    const entry = parseRosterValue(key, value, rules);
+    if (entry) out.push(entry);
   }
   return out;
+}
+
+/** Overlay expertProfiles onto roster (profiles win on same id/agent/key). */
+function mergeExpertProfiles(base: RosterEntry[], rules: ExpertsRules): RosterEntry[] {
+  const profiles = rules.expertProfiles;
+  if (!profiles || typeof profiles !== "object") return base;
+  const byId = new Map(base.map((e) => [e.id.toLowerCase(), { ...e }]));
+  for (const [key, value] of Object.entries(profiles)) {
+    const entry = parseRosterValue(key, value, rules);
+    if (!entry) continue;
+    const existing =
+      byId.get(entry.id.toLowerCase())
+      || byId.get(entry.agent.toLowerCase())
+      || byId.get(key.toLowerCase());
+    if (existing) {
+      const merged: RosterEntry = {
+        ...existing,
+        ...entry,
+        id: existing.id,
+        // Prefer profile fields when set; keep base when profile omits
+        model: entry.model ?? existing.model,
+        fallbackModels: entry.fallbackModels ?? existing.fallbackModels,
+        thinking: entry.thinking ?? existing.thinking,
+        channel: entry.channel ?? existing.channel,
+        skills: entry.skills ?? existing.skills,
+        agent: entry.agent || existing.agent,
+        defaultTaskType: entry.defaultTaskType || existing.defaultTaskType,
+      };
+      byId.set(existing.id.toLowerCase(), merged);
+    } else {
+      byId.set(entry.id.toLowerCase(), entry);
+    }
+  }
+  return [...byId.values()];
 }
 
 function rosterFromTaskTypes(rules: ExpertsRules): RosterEntry[] {

--- a/packages/pi-maestro-teammate/src/experts-mode/roster.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/roster.ts
@@ -1,0 +1,83 @@
+import { loadRules } from "./rules.ts";
+import type { ExpertsRules, RosterEntry } from "./types.ts";
+
+/**
+ * P6: resolve the project experts roster.
+ * Prefer explicit rules.roster; fall back to taskTypes → agent mapping.
+ * Never assigns models (role ≠ model).
+ */
+export function getRoster(rules: ExpertsRules = loadRules()): RosterEntry[] {
+  const fromConfig = rosterFromConfig(rules);
+  if (fromConfig.length > 0) return fromConfig;
+  return rosterFromTaskTypes(rules);
+}
+
+/** Lookup one roster entry by role id, agent name, or defaultTaskType. */
+export function resolveRosterEntry(
+  query: string,
+  rules: ExpertsRules = loadRules(),
+): RosterEntry | undefined {
+  const q = String(query || "").trim().toLowerCase();
+  if (!q) return undefined;
+  const list = getRoster(rules);
+  return (
+    list.find((e) => e.id.toLowerCase() === q)
+    || list.find((e) => e.agent.toLowerCase() === q)
+    || list.find((e) => e.defaultTaskType.toLowerCase() === q)
+    || list.find((e) => (e.label || "").toLowerCase() === q)
+  );
+}
+
+/** Map taskType → preferred agent via roster (else taskTypes / defaultAgent). */
+export function agentForTaskTypeFromRoster(
+  taskType: string,
+  rules: ExpertsRules = loadRules(),
+): string {
+  const list = getRoster(rules);
+  const hit = list.find(
+    (e) => e.enabled !== false && e.defaultTaskType === taskType,
+  );
+  if (hit?.agent) return hit.agent;
+  return rules.taskTypes?.[taskType]?.agent || rules.defaultAgent || "general";
+}
+
+function rosterFromConfig(rules: ExpertsRules): RosterEntry[] {
+  const raw = rules.roster;
+  if (!raw || typeof raw !== "object") return [];
+  const out: RosterEntry[] = [];
+  for (const [key, value] of Object.entries(raw)) {
+    if (!value || typeof value !== "object") continue;
+    const agent = String(value.agent || key).trim();
+    const defaultTaskType = String(
+      value.defaultTaskType || rules.defaultTaskType || "development",
+    ).trim();
+    if (!agent || !defaultTaskType) continue;
+    out.push({
+      id: String(value.id || key).trim() || key,
+      agent,
+      defaultTaskType,
+      label: value.label ? String(value.label) : undefined,
+      capabilities: Array.isArray(value.capabilities)
+        ? value.capabilities.map(String)
+        : undefined,
+      tools: Array.isArray(value.tools) ? value.tools.map(String) : undefined,
+      enabled: value.enabled === false ? false : true,
+    });
+  }
+  return out;
+}
+
+function rosterFromTaskTypes(rules: ExpertsRules): RosterEntry[] {
+  const types = rules.taskTypes || {};
+  return Object.entries(types).map(([taskType, cfg]) => {
+    const agent = String(cfg?.agent || rules.defaultAgent || "general");
+    return {
+      id: taskType,
+      agent,
+      defaultTaskType: taskType,
+      label: taskType,
+      capabilities: [taskType],
+      enabled: true,
+    } satisfies RosterEntry;
+  });
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/rules.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/rules.ts
@@ -86,13 +86,13 @@ export function mergeRules(base: ExpertsRules, overlay: ExpertsRules): ExpertsRu
       ? { ...(base.stageAliases || {}), ...overlay.stageAliases }
       : base.stageAliases,
     roster: overlay.roster
-      ? { ...(base.roster || {}), ...overlay.roster }
+      ? mergeRosterMaps(base.roster, overlay.roster)
       : base.roster,
     channels: overlay.channels
       ? { ...(base.channels || {}), ...overlay.channels }
       : base.channels,
     expertProfiles: overlay.expertProfiles
-      ? { ...(base.expertProfiles || {}), ...overlay.expertProfiles }
+      ? mergeRosterMaps(base.expertProfiles, overlay.expertProfiles)
       : base.expertProfiles,
     taskTypes: overlay.taskTypes
       ? { ...(base.taskTypes || {}), ...overlay.taskTypes }
@@ -101,4 +101,31 @@ export function mergeRules(base: ExpertsRules, overlay: ExpertsRules): ExpertsRu
       ? { ...(base.pipelines || {}), ...overlay.pipelines }
       : base.pipelines,
   };
+}
+
+/**
+ * M5: deep-merge roster / expertProfiles maps so a project overlay that only
+ * sets skills/model does not wipe package defaults (agent, capabilities, …).
+ * Overlay field wins when defined; arrays are replaced (not concatenated).
+ */
+export function mergeRosterMaps<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  base: Record<string, T> | undefined,
+  overlay: Record<string, T> | undefined,
+): Record<string, T> {
+  const out: Record<string, T> = { ...(base || {}) };
+  for (const [key, overlayEntry] of Object.entries(overlay || {})) {
+    if (!overlayEntry || typeof overlayEntry !== "object" || Array.isArray(overlayEntry)) {
+      out[key] = overlayEntry as T;
+      continue;
+    }
+    const baseEntry = out[key];
+    if (!baseEntry || typeof baseEntry !== "object" || Array.isArray(baseEntry)) {
+      out[key] = { ...overlayEntry } as T;
+      continue;
+    }
+    out[key] = { ...baseEntry, ...overlayEntry } as T;
+  }
+  return out;
 }

--- a/packages/pi-maestro-teammate/src/experts-mode/rules.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/rules.ts
@@ -88,6 +88,12 @@ export function mergeRules(base: ExpertsRules, overlay: ExpertsRules): ExpertsRu
     roster: overlay.roster
       ? { ...(base.roster || {}), ...overlay.roster }
       : base.roster,
+    channels: overlay.channels
+      ? { ...(base.channels || {}), ...overlay.channels }
+      : base.channels,
+    expertProfiles: overlay.expertProfiles
+      ? { ...(base.expertProfiles || {}), ...overlay.expertProfiles }
+      : base.expertProfiles,
     taskTypes: overlay.taskTypes
       ? { ...(base.taskTypes || {}), ...overlay.taskTypes }
       : base.taskTypes,

--- a/packages/pi-maestro-teammate/src/experts-mode/rules.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/rules.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExpertsRules } from "./types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_RULES_PATH = path.resolve(__dirname, "./config/default-rules.json");
+
+/** Project-level override (merged over package defaults). */
+export const PROJECT_RULES_FILENAME = ".experts-rules.json";
+
+let cachedRules: ExpertsRules | null = null;
+let cachedKey: string | null = null;
+
+/**
+ * Load experts rules: package default-rules.json, optionally merged with
+ * `<cwd>/.experts-rules.json` (shallow + settle/hardGate/stagePolicies deep-ish merge).
+ */
+export function loadRules(
+  rulesPath: string = DEFAULT_RULES_PATH,
+  cwd: string = process.cwd(),
+): ExpertsRules {
+  const basePath = path.resolve(rulesPath || DEFAULT_RULES_PATH);
+  const projectPath = path.resolve(cwd || process.cwd(), PROJECT_RULES_FILENAME);
+  const key = `${basePath}::${projectPath}`;
+  if (cachedRules && cachedKey === key) return cachedRules;
+
+  const base = JSON.parse(fs.readFileSync(basePath, "utf8")) as ExpertsRules;
+  let merged: ExpertsRules = base;
+  try {
+    if (fs.existsSync(projectPath)) {
+      const overlay = JSON.parse(fs.readFileSync(projectPath, "utf8")) as ExpertsRules;
+      merged = mergeRules(base, overlay);
+    }
+  } catch {
+    merged = base;
+  }
+
+  cachedRules = merged;
+  cachedKey = key;
+  return merged;
+}
+
+export function clearRulesCache(): void {
+  cachedRules = null;
+  cachedKey = null;
+}
+
+export function defaultRulesPath(): string {
+  return DEFAULT_RULES_PATH;
+}
+
+export function projectRulesPath(cwd = process.cwd()): string {
+  return path.resolve(cwd, PROJECT_RULES_FILENAME);
+}
+
+/** Shallow merge with nested merge for settle / hardGate / stagePolicies / roster / stageAliases. */
+export function mergeRules(base: ExpertsRules, overlay: ExpertsRules): ExpertsRules {
+  return {
+    ...base,
+    ...overlay,
+    hardGate: overlay.hardGate
+      ? {
+        ...base.hardGate,
+        ...overlay.hardGate,
+        tools: {
+          ...(base.hardGate?.tools || {}),
+          ...(overlay.hardGate?.tools || {}),
+        },
+        leaderAllowPaths: overlay.hardGate.leaderAllowPaths
+          ?? base.hardGate?.leaderAllowPaths,
+        bashAllowPrefixes: overlay.hardGate.bashAllowPrefixes
+          ?? base.hardGate?.bashAllowPrefixes,
+      }
+      : base.hardGate,
+    settle: overlay.settle
+      ? { ...base.settle, ...overlay.settle }
+      : base.settle,
+    orchestrator: overlay.orchestrator
+      ? { ...(base.orchestrator || {}), ...overlay.orchestrator }
+      : base.orchestrator,
+    stagePolicies: overlay.stagePolicies
+      ? { ...(base.stagePolicies || {}), ...overlay.stagePolicies }
+      : base.stagePolicies,
+    stageAliases: overlay.stageAliases
+      ? { ...(base.stageAliases || {}), ...overlay.stageAliases }
+      : base.stageAliases,
+    roster: overlay.roster
+      ? { ...(base.roster || {}), ...overlay.roster }
+      : base.roster,
+    taskTypes: overlay.taskTypes
+      ? { ...(base.taskTypes || {}), ...overlay.taskTypes }
+      : base.taskTypes,
+    pipelines: overlay.pipelines
+      ? { ...(base.pipelines || {}), ...overlay.pipelines }
+      : base.pipelines,
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/self-evolve-deposit.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/self-evolve-deposit.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type { KnowledgeHarvestSuggestion } from "./types.ts";
+
+/**
+ * P7b: deposit experts harvest suggestions into the self-evolve *pending*
+ * suggestions pool (`~/.maestro/self-evolve/suggestions/YYYY-MM-DD.jsonl`).
+ *
+ * Compatible with SelfEvolveSignal schema (schemaVersion 1, kind candidate)
+ * so `/self-evolve review` and auto-deposit can see them later.
+ *
+ * Never promotes. Never runs `maestro knowledge stage` here — that stays on
+ * self-evolve auto-deposit after human/LLM review, or Leader manual stage.
+ */
+
+export interface SelfEvolvePoolDepositResult {
+  written: number;
+  skipped: number;
+  filePath?: string;
+  ids: string[];
+  errors: string[];
+}
+
+export interface DepositToSelfEvolvePoolOptions {
+  /** Override output root (default ~/.maestro/self-evolve or SELF_EVOLVE_OUTPUT_DIR). */
+  outputRoot?: string;
+  cwd?: string;
+  sessionId?: string;
+  runId?: string;
+  project?: string;
+  /** Skip ids already present in today's file (default true). */
+  dedupe?: boolean;
+}
+
+export function selfEvolveOutputRoot(envValue?: string): string {
+  const fromEnv = (envValue ?? process.env.SELF_EVOLVE_OUTPUT_DIR)?.trim();
+  if (fromEnv) return path.resolve(fromEnv);
+  return path.join(os.homedir(), ".maestro", "self-evolve");
+}
+
+export function suggestionsDirPath(outputRoot: string): string {
+  return path.join(outputRoot, "suggestions");
+}
+
+export function dailySuggestionFileName(date = new Date()): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}.jsonl`;
+}
+
+/** Map harvest suggestion → SelfEvolveSignal-compatible record. */
+export function harvestToSelfEvolveSignal(
+  suggestion: KnowledgeHarvestSuggestion,
+  opts: {
+    sessionId?: string;
+    runId?: string;
+    project?: string;
+  } = {},
+): Record<string, unknown> {
+  const sessionId = suggestion.sessionId || opts.sessionId || "experts-session";
+  const runId = suggestion.runId || opts.runId;
+  const traceHash = suggestion.fingerprint;
+  const id = `se-${traceHash.slice(0, 12)}`;
+  const candidateType = suggestion.target === "spec" ? "spec" : "knowhow";
+  const evidence: Array<{ type: string; ref: string; role?: string }> =
+    (suggestion.evidence || []).map((ref) => ({
+      type: "file",
+      ref,
+    }));
+  if (suggestion.agentId) {
+    evidence.push({ type: "tool", ref: `experts:${suggestion.agentId}` });
+  }
+  const title = suggestion.title.slice(0, 120);
+  const summary = suggestion.content.slice(0, 2000);
+  const stageHint = [
+    "maestro knowledge stage",
+    candidateType,
+    JSON.stringify(title),
+    "--content-file -",
+    sessionId ? `--session ${sessionId}` : "",
+    runId ? `--run ${runId}` : "",
+    "--category",
+    suggestion.kind,
+  ].filter(Boolean).join(" ");
+
+  return {
+    schemaVersion: 1,
+    id,
+    kind: "candidate",
+    source: "agent_end",
+    dryRun: true,
+    createdAt: suggestion.at || new Date().toISOString(),
+    sessionId,
+    ...(opts.project ? { project: opts.project } : {}),
+    skill: "experts-harvest",
+    ...(runId ? { runId } : {}),
+    traceHash,
+    candidateType,
+    title,
+    summary,
+    evidence: evidence.length
+      ? evidence
+      : [{ type: "tool", ref: "experts-settle-harvest" }],
+    suggestion: stageHint,
+    trigger: {
+      reason: `experts-harvest:${suggestion.kind}`,
+    },
+    // Non-schema extension fields (ignored by strict readers, useful for audit)
+    expertsHarvestId: suggestion.id,
+    expertsKind: suggestion.kind,
+    expertsScore: suggestion.score,
+  };
+}
+
+/**
+ * Append harvest suggestions to today's self-evolve suggestions jsonl.
+ */
+export function depositHarvestToSelfEvolvePool(
+  suggestions: readonly KnowledgeHarvestSuggestion[],
+  opts: DepositToSelfEvolvePoolOptions = {},
+): SelfEvolvePoolDepositResult {
+  if (!suggestions.length) {
+    return { written: 0, skipped: 0, ids: [], errors: [] };
+  }
+  const root = opts.outputRoot
+    ? path.resolve(opts.outputRoot)
+    : selfEvolveOutputRoot();
+  const dir = suggestionsDirPath(root);
+  const filePath = path.join(dir, dailySuggestionFileName());
+  const errors: string[] = [];
+  const ids: string[] = [];
+  let written = 0;
+  let skipped = 0;
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (error) {
+    return {
+      written: 0,
+      skipped: suggestions.length,
+      errors: [error instanceof Error ? error.message : String(error)],
+      ids: [],
+    };
+  }
+
+  const existing = new Set<string>();
+  if (opts.dedupe !== false && fs.existsSync(filePath)) {
+    try {
+      const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/).filter(Boolean);
+      for (const line of lines) {
+        try {
+          const row = JSON.parse(line) as { id?: string; traceHash?: string };
+          if (row.id) existing.add(row.id);
+          if (row.traceHash) existing.add(`th:${row.traceHash}`);
+        } catch {
+          /* skip bad line */
+        }
+      }
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  const project = opts.project
+    || (opts.cwd ? path.basename(opts.cwd) : undefined);
+
+  const chunks: string[] = [];
+  for (const suggestion of suggestions) {
+    const signal = harvestToSelfEvolveSignal(suggestion, {
+      sessionId: opts.sessionId,
+      runId: opts.runId,
+      project,
+    });
+    const id = String(signal.id);
+    const th = `th:${String(signal.traceHash)}`;
+    if (existing.has(id) || existing.has(th)) {
+      skipped++;
+      continue;
+    }
+    existing.add(id);
+    existing.add(th);
+    chunks.push(`${JSON.stringify(signal)}\n`);
+    // Also write evidence markdown so stage template can use --content-file
+    try {
+      const evidenceDir = path.join(root, "evidence");
+      fs.mkdirSync(evidenceDir, { recursive: true });
+      const evidencePath = path.join(evidenceDir, `${id}.md`);
+      if (!fs.existsSync(evidencePath)) {
+        const body = [
+          `# ${suggestion.title}`,
+          "",
+          suggestion.content,
+          "",
+          `source: experts-settle · kind: ${suggestion.kind} · score: ${suggestion.score}`,
+          suggestion.agentId ? `agent: ${suggestion.agentId}` : "",
+          suggestion.taskType ? `taskType: ${suggestion.taskType}` : "",
+          suggestion.stage ? `stage: ${suggestion.stage}` : "",
+        ].filter(Boolean).join("\n");
+        fs.writeFileSync(evidencePath, `${body}\n`, "utf8");
+      }
+      // Upgrade suggestion command to real evidence file path
+      signal.suggestion = [
+        "maestro knowledge stage",
+        signal.candidateType === "spec" ? "spec" : "knowhow",
+        JSON.stringify(suggestion.title),
+        "--content-file",
+        evidencePath,
+        opts.sessionId || suggestion.sessionId
+          ? `--session ${opts.sessionId || suggestion.sessionId}`
+          : "",
+        opts.runId || suggestion.runId
+          ? `--run ${opts.runId || suggestion.runId}`
+          : "",
+        "--category",
+        suggestion.kind,
+      ].filter(Boolean).join(" ");
+      // rewrite last chunk with updated suggestion
+      chunks[chunks.length - 1] = `${JSON.stringify(signal)}\n`;
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+    ids.push(id);
+    written++;
+  }
+
+  if (chunks.length) {
+    try {
+      fs.appendFileSync(filePath, chunks.join(""), "utf8");
+    } catch (error) {
+      return {
+        written: 0,
+        skipped: suggestions.length,
+        filePath,
+        ids: [],
+        errors: [...errors, error instanceof Error ? error.message : String(error)],
+      };
+    }
+  }
+
+  return { written, skipped, filePath, ids, errors };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/stage-policy.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/stage-policy.ts
@@ -1,0 +1,310 @@
+import { getMode, resolveStatePath } from "./mode.ts";
+import { recordLastDispatch } from "./observe.ts";
+import { loadRules } from "./rules.ts";
+import { classifyIntent } from "./triage.ts";
+import type {
+  ExpertsMode,
+  ExpertsRules,
+  ExpertsTaskType,
+  StageExpertsPlan,
+  StagePipelineStep,
+  StagePolicy,
+  TeammateTaskLike,
+} from "./types.ts";
+import fs from "node:fs";
+import path from "node:path";
+
+/** Built-in aliases so Maestro chain commands map to policy keys. */
+export const DEFAULT_STAGE_ALIASES: Record<string, string> = {
+  analyze: "analyze",
+  "analyze-macro": "analyze",
+  "maestro-analyze": "analyze",
+  plan: "plan",
+  "maestro-plan": "plan",
+  planning: "plan",
+  execute: "execute",
+  "maestro-execute": "execute",
+  development: "execute",
+  implement: "execute",
+  review: "review",
+  "maestro-review": "review",
+  "quality-review": "review",
+  test: "test",
+  "quality-test": "test",
+  "auto-test": "test",
+  testing: "test",
+  debug: "debug",
+  "quality-debug": "debug",
+  verify: "test",
+  verification: "test",
+  harvest: "review",
+  learn: "analyze",
+  grill: "analyze",
+  companion: "execute",
+};
+
+export interface ResolveStageExpertsPlanOptions {
+  mode?: ExpertsMode;
+  cwd?: string;
+  rules?: ExpertsRules;
+  chainCommand?: string;
+  /** When true, persist activeStage + lastStagePlan into .experts-mode.json */
+  record?: boolean;
+  /** Extra leader-facing notes appended to leaderInstructions */
+  extraLeaderNotes?: string;
+}
+
+/**
+ * Normalize a Maestro step/command/stage string to a stage policy key.
+ */
+export function resolveStageName(
+  stageOrCommand: string | undefined | null,
+  rules: ExpertsRules = loadRules(),
+): string | undefined {
+  if (!stageOrCommand || typeof stageOrCommand !== "string") return undefined;
+  const raw = stageOrCommand.trim().toLowerCase();
+  if (!raw) return undefined;
+  const aliases = { ...DEFAULT_STAGE_ALIASES, ...(rules.stageAliases || {}) };
+  if (aliases[raw]) return aliases[raw];
+  // strip leading maestro- / quality-
+  const stripped = raw.replace(/^(maestro-|quality-)/, "");
+  if (aliases[stripped]) return aliases[stripped];
+  if (rules.stagePolicies?.[raw]) return raw;
+  if (rules.stagePolicies?.[stripped]) return stripped;
+  return raw;
+}
+
+export function getStagePolicy(
+  stageOrCommand: string | undefined | null,
+  rules: ExpertsRules = loadRules(),
+): { stage: string; policy: StagePolicy } | undefined {
+  const stage = resolveStageName(stageOrCommand, rules);
+  if (!stage) return undefined;
+  const policy = rules.stagePolicies?.[stage];
+  if (!policy || !Array.isArray(policy.pipeline) || policy.pipeline.length === 0) {
+    return undefined;
+  }
+  return { stage, policy };
+}
+
+function agentForType(taskType: string, rules: ExpertsRules): string {
+  return rules.taskTypes?.[taskType]?.agent || rules.defaultAgent || "general";
+}
+
+function stepToTask(
+  step: StagePipelineStep,
+  index: number,
+  intent: string,
+  stage: string,
+  rules: ExpertsRules,
+): TeammateTaskLike {
+  const taskType = String(step.taskType || rules.defaultTaskType || "development");
+  const agent = step.agent || agentForType(taskType, rules);
+  const name = step.name || `${stage}-${taskType}-${index + 1}`;
+  const roleHint = `You are the ${agent} expert for Maestro stage "${stage}" (taskType=${taskType}).`;
+  const prompt = [
+    roleHint,
+    `Stage goal / user intent: ${intent || "(unspecified)"}`,
+    "Produce concrete, evidence-backed work for this stage only.",
+    "Do not hardcode model ids. Keep role ≠ model.",
+  ].join("\n");
+  const task: TeammateTaskLike = {
+    name,
+    prompt,
+    agent,
+    taskType,
+  };
+  if (Array.isArray(step.dependsOn) && step.dependsOn.length > 0) {
+    task.dependsOn = step.dependsOn;
+  }
+  return task;
+}
+
+/**
+ * Resolve the experts plan for a Maestro chain stage.
+ * Stage policy defaults beat keyword triage when a policy exists.
+ * In normal mode returns empty tasks (no force).
+ */
+export function resolveStageExpertsPlan(
+  stageOrCommand: string,
+  intent: string,
+  opts: ResolveStageExpertsPlanOptions = {},
+): StageExpertsPlan {
+  const cwd = opts.cwd ?? process.cwd();
+  const mode = opts.mode ?? getMode(cwd);
+  const rules = opts.rules ?? loadRules();
+  const stage = resolveStageName(stageOrCommand, rules) || String(stageOrCommand || "").trim() || "unknown";
+  const found = getStagePolicy(stage, rules);
+
+  if (mode !== "experts") {
+    return {
+      mode: "normal",
+      stage,
+      source: "none",
+      tasks: [],
+      leaderInstructions:
+        "Experts Mode is OFF. Execute normally; no stage expert pipeline is forced.",
+      policy: found?.policy,
+    };
+  }
+
+  let tasks: TeammateTaskLike[] = [];
+  let source: StageExpertsPlan["source"] = "none";
+  let policy = found?.policy;
+
+  if (found) {
+    tasks = found.policy.pipeline.map((step, i) =>
+      stepToTask(step, i, intent, found.stage, rules),
+    );
+    source = "stage-policy";
+    policy = found.policy;
+  } else {
+    // Fallback: keyword triage single task + optional pipeline expansion from rules.pipelines
+    const triage = classifyIntent(intent || stage, rules);
+    const pipelineTypes: string[] =
+      (triage.pipeline && triage.pipeline.length > 0
+        ? triage.pipeline
+        : rules.pipelines?.full_feature) || [triage.taskType];
+    tasks = pipelineTypes.map((taskType, i) =>
+      stepToTask(
+        { taskType: taskType as ExpertsTaskType, agent: agentForType(taskType, rules) },
+        i,
+        intent,
+        stage,
+        rules,
+      ),
+    );
+    // Prefer primary triage type on first task
+    if (tasks[0]) {
+      tasks[0].taskType = triage.taskType;
+      tasks[0].agent = triage.agent;
+    }
+    source = "triage-fallback";
+  }
+
+  const forbid = policy?.forbidMain?.length
+    ? `Forbid main-session heavy work: ${policy.forbidMain.join("; ")}.`
+    : "Do not implement broad feature work yourself with write/edit/bash.";
+  const mayWrite = policy?.leaderMayWrite?.length
+    ? `Leader may write only: ${policy.leaderMayWrite.join(", ")}.`
+    : "Leader writes orchestration artifacts only (report.md, outputs/*.json, session/run commands).";
+
+  const leaderInstructions = [
+    `Experts Mode ON · stage="${stage}" · source=${source}.`,
+    "You are the Leader (orchestrator) for this Maestro stage.",
+    `Dispatch the stage expert pipeline via teammate (tasks already typed). ${forbid}`,
+    mayWrite,
+    "Call order: ensureExpertsDispatch(params,{stage}) → applyModelRouting — never hardcode models.",
+    "After experts settle: synthesize into Run artifacts and continue Maestro session done/check.",
+    opts.extraLeaderNotes || "",
+    opts.chainCommand ? `chainCommand=${opts.chainCommand}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const plan: StageExpertsPlan = {
+    mode: "experts",
+    stage: found?.stage || stage,
+    source,
+    tasks,
+    leaderInstructions,
+    policy,
+  };
+
+  if (opts.record !== false) {
+    try {
+      writeActiveStage(cwd, {
+        stage: plan.stage,
+        source: plan.source,
+        taskTypes: plan.tasks.map((t) => String(t.taskType || "")),
+        agents: plan.tasks.map((t) => String(t.agent || "")),
+        intentPreview: String(intent || "").slice(0, 160),
+        at: new Date().toISOString(),
+      });
+      if (plan.tasks[0]) {
+        recordLastDispatch(
+          {
+            mode: "experts",
+            taskType: plan.tasks[0].taskType ? String(plan.tasks[0].taskType) : undefined,
+            agent: plan.tasks[0].agent ? String(plan.tasks[0].agent) : undefined,
+            forced: true,
+            at: new Date().toISOString(),
+            promptPreview: String(intent || "").slice(0, 120),
+            stage: plan.stage,
+          },
+          cwd,
+        );
+      }
+    } catch {
+      // state persistence must not break planning
+    }
+  }
+
+  return plan;
+}
+
+export interface ActiveStageState {
+  stage: string;
+  source?: string;
+  taskTypes?: string[];
+  agents?: string[];
+  intentPreview?: string;
+  /** P4.1: Maestro session/run that produced this stage (source="maestro-session"). */
+  sessionId?: string;
+  runId?: string;
+  at?: string;
+}
+
+export function writeActiveStage(
+  cwd = process.cwd(),
+  activeStage: ActiveStageState,
+  statePath?: string,
+): void {
+  const file = resolveStatePath(cwd, statePath);
+  let prev: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(file)) prev = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    prev = {};
+  }
+  const next = {
+    ...prev,
+    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, statePath),
+    activeStage,
+    updatedAt: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+export function readActiveStage(cwd = process.cwd(), statePath?: string): ActiveStageState | null {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) return null;
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as { activeStage?: ActiveStageState };
+    if (!raw?.activeStage || typeof raw.activeStage.stage !== "string") return null;
+    return raw.activeStage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Given a single teammate task without taskType, fill from stage policy primary step.
+ * Returns undefined when no stage policy applies.
+ */
+export function primaryStageAssignment(
+  stageOrCommand: string | undefined,
+  rules: ExpertsRules = loadRules(),
+): { taskType: string; agent: string; stage: string } | undefined {
+  const found = getStagePolicy(stageOrCommand, rules);
+  if (!found) return undefined;
+  const step = found.policy.pipeline[0];
+  if (!step) return undefined;
+  const taskType = String(step.taskType);
+  return {
+    stage: found.stage,
+    taskType,
+    agent: step.agent || agentForType(taskType, rules),
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/state-io.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/state-io.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Atomic JSON state write for .experts-mode.json (and similar).
+ * Writes to a temp file in the same directory then renames (best-effort
+ * atomic on Windows with short retries).
+ */
+export function writeJsonStateFile(
+  filePath: string,
+  data: unknown,
+  opts: { retries?: number } = {},
+): void {
+  const file = path.resolve(filePath);
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true });
+  const payload = `${JSON.stringify(data, null, 2)}\n`;
+  const tmp = path.join(
+    dir,
+    `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  const retries = opts.retries ?? 3;
+  let lastErr: unknown;
+  for (let i = 0; i < retries; i++) {
+    try {
+      fs.writeFileSync(tmp, payload, "utf8");
+      try {
+        fs.renameSync(tmp, file);
+      } catch {
+        // Windows: replace existing target
+        try {
+          fs.rmSync(file, { force: true });
+        } catch {
+          /* ignore */
+        }
+        fs.renameSync(tmp, file);
+      }
+      return;
+    } catch (err) {
+      lastErr = err;
+      try {
+        fs.rmSync(tmp, { force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  // Last resort: direct write so callers still persist state
+  try {
+    fs.writeFileSync(file, payload, "utf8");
+  } catch (err) {
+    throw lastErr || err;
+  }
+}
+
+export function readJsonStateFile(filePath: string): Record<string, unknown> {
+  const file = path.resolve(filePath);
+  try {
+    if (!fs.existsSync(file)) return {};
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as unknown;
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      return raw as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/state-io.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/state-io.ts
@@ -66,3 +66,73 @@ export function readJsonStateFile(filePath: string): Record<string, unknown> {
     return {};
   }
 }
+
+/** Per-path async mutex chain (MV-02). */
+const lockChains = new Map<string, Promise<void>>();
+/** Sync re-entry depth per path (same tick / nested mutate). */
+const syncDepth = new Map<string, number>();
+
+function lockKey(filePath: string): string {
+  return path.resolve(filePath);
+}
+
+/**
+ * MV-02: serialize async RMW on a state file.
+ * Callers that await between read and write should wrap the whole critical section.
+ */
+export async function withStateLock<T>(
+  filePath: string,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const key = lockKey(filePath);
+  const prev = lockChains.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const next = prev.then(() => gate);
+  lockChains.set(key, next);
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+    // Drop the chain head when we are still the tail waiter
+    if (lockChains.get(key) === next) {
+      lockChains.delete(key);
+    }
+  }
+}
+
+/**
+ * MV-02: single-process sync critical section for state RMW.
+ * Nesting on the same path is allowed (depth counter); concurrent async
+ * callers still rely on withStateLock or on not awaiting mid-mutation.
+ */
+export function withStateLockSync<T>(filePath: string, fn: () => T): T {
+  const key = lockKey(filePath);
+  const depth = syncDepth.get(key) ?? 0;
+  syncDepth.set(key, depth + 1);
+  try {
+    return fn();
+  } finally {
+    const d = (syncDepth.get(key) ?? 1) - 1;
+    if (d <= 0) syncDepth.delete(key);
+    else syncDepth.set(key, d);
+  }
+}
+
+/**
+ * Read → mutate → atomic write under the sync lock (preferred RMW helper).
+ */
+export function mutateJsonStateFile(
+  filePath: string,
+  mutator: (prev: Record<string, unknown>) => Record<string, unknown>,
+): Record<string, unknown> {
+  return withStateLockSync(filePath, () => {
+    const prev = readJsonStateFile(filePath);
+    const next = mutator({ ...prev });
+    writeJsonStateFile(filePath, next);
+    return next;
+  });
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
@@ -32,17 +32,17 @@ export function formatExpertsStatusPanelFromStatus(status: ExpertsStatus): strin
   const lines: string[] = ["=== Experts Mode Status ==="];
 
   // Mode
-  lines.push(`Mode: ${status.mode}`);
+  lines.push("", `Mode: ${status.mode}`);
 
   // LeaderWaiting: yes/no + count + agent ids (comma, max 6)
   const waitingIds = (status.leaderWaitingAgentIds ?? []).slice(0, 6).join(", ");
-  lines.push(status.leaderWaiting
+  lines.push("", status.leaderWaiting
     ? `LeaderWaiting: yes (${status.leaderWaitingCount})${waitingIds ? ` agents=[${waitingIds}]` : ""}`
     : "LeaderWaiting: no");
 
   // ActiveStage: stage + source if present, else "(none)"
   const stage = status.activeStage;
-  lines.push(stage
+  lines.push("", stage
     ? `ActiveStage: ${stage.stage}${stage.source ? ` (source=${stage.source})` : ""}`
     : "ActiveStage: (none)");
 
@@ -51,11 +51,11 @@ export function formatExpertsStatusPanelFromStatus(status: ExpertsStatus): strin
     ? status.lastDispatch
     : null) as DispatchRecord | null;
   const last = lastDispatchFields(lastRecord);
-  lines.push(last.length ? `LastDispatch: ${last.join(" ")}` : "LastDispatch: (none)");
+  lines.push("", last.length ? `LastDispatch: ${last.join(" ")}` : "LastDispatch: (none)");
 
   // InFlight: count + list name|id|agent|taskType (max 8)
   const inFlight: InFlightExpert[] = status.inFlight ?? [];
-  lines.push(inFlight.length ? `InFlight: ${inFlight.length}` : "InFlight: 0");
+  lines.push("", inFlight.length ? `InFlight: ${inFlight.length}` : "InFlight: 0");
   for (const entry of inFlight.slice(0, 8)) {
     const parts: string[] = [];
     if (entry.name) parts.push(`name=${entry.name}`);
@@ -67,10 +67,10 @@ export function formatExpertsStatusPanelFromStatus(status: ExpertsStatus): strin
 
   // Harvest
   const harvest = formatExpertsHarvestStatus(status.knowledgeSuggestions ?? []);
-  lines.push(harvest ? `Harvest: ${harvest}` : "Harvest: (none)");
+  lines.push("", harvest ? `Harvest: ${harvest}` : "Harvest: (none)");
 
   // Path + updatedAt if present
-  lines.push(`Path: ${status.path}`);
+  lines.push("", `Path: ${status.path}`);
   if (status.updatedAt) lines.push(`updatedAt: ${status.updatedAt}`);
 
   return lines.join("\n");
@@ -78,4 +78,115 @@ export function formatExpertsStatusPanelFromStatus(status: ExpertsStatus): strin
 
 export function formatExpertsStatusPanel(cwd = process.cwd(), statePath?: string): string {
   return formatExpertsStatusPanelFromStatus(getStatus(cwd, statePath));
+}
+
+/** CLI panel views for the /experts command (roster|waiting|harvest|status). */
+export type ExpertsPanelView = "status" | "roster" | "waiting" | "harvest";
+
+/**
+ * Roster section — roles only, never models.
+ * Enabled entries first; each row: id | agent | taskType | label | caps | enabled.
+ */
+export function formatExpertsRosterPanelFromStatus(status: ExpertsStatus): string {
+  const lines: string[] = ["=== Experts Roster ==="];
+  const roster = (status.roster ?? []).slice().sort((a, b) => {
+    if ((a.enabled !== false) !== (b.enabled !== false)) return a.enabled === false ? 1 : -1;
+    return a.id.localeCompare(b.id);
+  });
+  if (roster.length === 0) {
+    lines.push("(no roster — using taskType defaults)");
+  } else {
+    for (const entry of roster) {
+      const caps = (entry.capabilities ?? []).join(",");
+      lines.push([
+        entry.id,
+        entry.agent,
+        entry.defaultTaskType,
+        entry.label ?? "",
+        caps,
+        entry.enabled === false ? "disabled" : "enabled",
+      ].join(" | "));
+    }
+  }
+  lines.push("role ≠ model — routing owns models");
+  return lines.join("\n");
+}
+
+/**
+ * Waiting section — leaderWaiting + in-flight expert units + active stage.
+ * While leaderWaiting, the Lead must not claim done.
+ */
+export function formatExpertsWaitingPanelFromStatus(status: ExpertsStatus): string {
+  const lines: string[] = ["=== Experts Waiting ==="];
+  const ids = (status.leaderWaitingAgentIds ?? []).join(", ");
+  lines.push(status.leaderWaiting
+    ? `LeaderWaiting: yes (${status.leaderWaitingCount})${ids ? ` agents=[${ids}]` : ""}`
+    : "LeaderWaiting: no");
+
+  const inFlight: InFlightExpert[] = (status.inFlight ?? []).slice(0, 20);
+  lines.push(inFlight.length ? `InFlight: ${inFlight.length}` : "InFlight: 0");
+  for (const entry of inFlight) {
+    const parts: string[] = [];
+    if (entry.name) parts.push(`name=${entry.name}`);
+    parts.push(`id=${entry.id}`);
+    if (entry.agent) parts.push(`agent=${entry.agent}`);
+    if (entry.taskType) parts.push(`taskType=${entry.taskType}`);
+    lines.push(`  - ${parts.join(" ")}`);
+  }
+
+  const stage = status.activeStage;
+  lines.push(stage
+    ? `ActiveStage: ${stage.stage}${stage.source ? ` (source=${stage.source})` : ""}`
+    : "ActiveStage: (none)");
+
+  if (status.leaderWaiting) {
+    lines.push("Hint: do not claim done while waiting — consume teammate-complete/settle first");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Harvest section — pending P7 knowhow suggestions (never auto-promoted).
+ * Suggestion rows: id | kind | title (≤72) | score; max 20 rows.
+ */
+export function formatExpertsHarvestPanelFromStatus(status: ExpertsStatus): string {
+  const lines: string[] = ["=== Experts Harvest ==="];
+  const suggestions = status.knowledgeSuggestions ?? [];
+  const summary = formatExpertsHarvestStatus(suggestions);
+  if (!summary) {
+    lines.push("(none — settle harvest is suggest-only)");
+  } else {
+    lines.push(`Summary: ${summary}`);
+    for (const s of suggestions.slice(0, 20)) {
+      lines.push(`  - ${s.id} | ${s.kind} | ${truncate(s.title, 72)} | score=${s.score}`);
+    }
+  }
+  lines.push("Never auto-promote — stage only via maestro knowledge stage");
+  return lines.join("\n");
+}
+
+/** View dispatcher for the /experts CLI (default status view). */
+export function formatExpertsPanelFromStatus(
+  status: ExpertsStatus,
+  view: ExpertsPanelView = "status",
+): string {
+  switch (view) {
+    case "roster":
+      return formatExpertsRosterPanelFromStatus(status);
+    case "waiting":
+      return formatExpertsWaitingPanelFromStatus(status);
+    case "harvest":
+      return formatExpertsHarvestPanelFromStatus(status);
+    case "status":
+    default:
+      return formatExpertsStatusPanelFromStatus(status);
+  }
+}
+
+export function formatExpertsPanel(
+  cwd = process.cwd(),
+  view: ExpertsPanelView = "status",
+  statePath?: string,
+): string {
+  return formatExpertsPanelFromStatus(getStatus(cwd, statePath), view);
 }

--- a/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
@@ -1,0 +1,81 @@
+import type { ExpertsStatus } from "./observe.ts";
+import { getStatus } from "./observe.ts";
+import { formatExpertsHarvestStatus } from "./harvest-status.ts";
+import type { DispatchRecord, InFlightExpert } from "./types.ts";
+
+function truncate(text: unknown, max: number): string {
+  const s = String(text ?? "").replace(/\s+/g, " ").trim();
+  if (s.length <= max) return s;
+  return `${s.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/**
+ * LastDispatch line fields — taskType/agent/stage/forced/at/promptPreview.
+ * The model field is deliberately omitted even when the record carries one:
+ * routing owns models, the panel never leaks model ids.
+ */
+function lastDispatchFields(record: DispatchRecord | null): string[] {
+  if (!record) return [];
+  const fields: string[] = [];
+  if (record.taskType) fields.push(`taskType=${record.taskType}`);
+  if (record.agent) fields.push(`agent=${record.agent}`);
+  if (record.stage) fields.push(`stage=${record.stage}`);
+  fields.push(`forced=${Boolean(record.forced)}`);
+  if (record.at) fields.push(`at=${record.at}`);
+  const preview = truncate(record.promptPreview, 80);
+  if (preview) fields.push(`prompt="${preview}"`);
+  return fields;
+}
+
+/** Pure formatter — no disk writes, no model ids. */
+export function formatExpertsStatusPanelFromStatus(status: ExpertsStatus): string {
+  const lines: string[] = ["=== Experts Mode Status ==="];
+
+  // Mode
+  lines.push(`Mode: ${status.mode}`);
+
+  // LeaderWaiting: yes/no + count + agent ids (comma, max 6)
+  const waitingIds = (status.leaderWaitingAgentIds ?? []).slice(0, 6).join(", ");
+  lines.push(status.leaderWaiting
+    ? `LeaderWaiting: yes (${status.leaderWaitingCount})${waitingIds ? ` agents=[${waitingIds}]` : ""}`
+    : "LeaderWaiting: no");
+
+  // ActiveStage: stage + source if present, else "(none)"
+  const stage = status.activeStage;
+  lines.push(stage
+    ? `ActiveStage: ${stage.stage}${stage.source ? ` (source=${stage.source})` : ""}`
+    : "ActiveStage: (none)");
+
+  // LastDispatch — omit model field entirely even if present on record
+  const lastRecord = (status.lastDispatch && typeof status.lastDispatch === "object"
+    ? status.lastDispatch
+    : null) as DispatchRecord | null;
+  const last = lastDispatchFields(lastRecord);
+  lines.push(last.length ? `LastDispatch: ${last.join(" ")}` : "LastDispatch: (none)");
+
+  // InFlight: count + list name|id|agent|taskType (max 8)
+  const inFlight: InFlightExpert[] = status.inFlight ?? [];
+  lines.push(inFlight.length ? `InFlight: ${inFlight.length}` : "InFlight: 0");
+  for (const entry of inFlight.slice(0, 8)) {
+    const parts: string[] = [];
+    if (entry.name) parts.push(`name=${entry.name}`);
+    parts.push(`id=${entry.id}`);
+    if (entry.agent) parts.push(`agent=${entry.agent}`);
+    if (entry.taskType) parts.push(`taskType=${entry.taskType}`);
+    lines.push(`  - ${parts.join(" ")}`);
+  }
+
+  // Harvest
+  const harvest = formatExpertsHarvestStatus(status.knowledgeSuggestions ?? []);
+  lines.push(harvest ? `Harvest: ${harvest}` : "Harvest: (none)");
+
+  // Path + updatedAt if present
+  lines.push(`Path: ${status.path}`);
+  if (status.updatedAt) lines.push(`updatedAt: ${status.updatedAt}`);
+
+  return lines.join("\n");
+}
+
+export function formatExpertsStatusPanel(cwd = process.cwd(), statePath?: string): string {
+  return formatExpertsStatusPanelFromStatus(getStatus(cwd, statePath));
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/status-panel.ts
@@ -98,17 +98,22 @@ export function formatExpertsRosterPanelFromStatus(status: ExpertsStatus): strin
   } else {
     for (const entry of roster) {
       const caps = (entry.capabilities ?? []).join(",");
-      lines.push([
+      const parts = [
         entry.id,
         entry.agent,
         entry.defaultTaskType,
         entry.label ?? "",
         caps,
         entry.enabled === false ? "disabled" : "enabled",
-      ].join(" | "));
+      ];
+      if (entry.channel) parts.push(`channel=${entry.channel}`);
+      if (entry.model) parts.push(`model=${truncate(entry.model, 40)}`);
+      if (entry.skills?.length) parts.push(`skills=${entry.skills.slice(0, 4).join(",")}`);
+      if (entry.thinking) parts.push(`thinking=${entry.thinking}`);
+      lines.push(parts.join(" | "));
     }
   }
-  lines.push("role ≠ model — routing owns models");
+  lines.push("role ≠ model — profile may map role→model/channel/skills via .experts-rules.json");
   return lines.join("\n");
 }
 

--- a/packages/pi-maestro-teammate/src/experts-mode/triage.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/triage.ts
@@ -1,0 +1,107 @@
+import { loadRules } from "./rules.ts";
+import type { ExpertsRules, ExpertsTaskType, TriageResult } from "./types.ts";
+
+function matchesKeyword(text: string, keyword: string): boolean {
+  const t = text.toLowerCase();
+  const k = keyword.toLowerCase();
+  if (!k) return false;
+  if (/[\u4e00-\u9fff]/.test(k) || k.length <= 3) return t.includes(k);
+  const re = new RegExp(
+    `(?:^|[^a-z0-9_])${k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:$|[^a-z0-9_])`,
+    "i",
+  );
+  return re.test(text) || t.includes(k);
+}
+
+export function classifyIntent(text: string, rules: ExpertsRules = loadRules()): TriageResult {
+  const input = String(text ?? "").trim();
+  const matchedRules: string[] = [];
+
+  if (!input) {
+    return {
+      taskType: (rules.defaultTaskType as ExpertsTaskType) || "development",
+      agent: rules.defaultAgent || "general-executor",
+      heavy: false,
+      pipeline: (rules.pipelines?.tiny_fix as ExpertsTaskType[]) || ["development"],
+      matchedRules: ["empty"],
+      reason: "empty input → default light development",
+    };
+  }
+
+  for (const kw of rules.lightKeywords || []) {
+    if (matchesKeyword(input, kw) && input.length < 40) {
+      matchedRules.push(`light:${kw}`);
+      return {
+        taskType: "analysis",
+        agent: "general",
+        heavy: false,
+        pipeline: [],
+        matchedRules,
+        reason: `light intent matched "${kw}"`,
+      };
+    }
+  }
+
+  const hits: Array<{
+    taskType: ExpertsTaskType;
+    score: number;
+    agent: string;
+    heavy: boolean;
+  }> = [];
+
+  for (const [taskType, meta] of Object.entries(rules.taskTypes || {})) {
+    let score = 0;
+    for (const kw of meta.keywords || []) {
+      if (matchesKeyword(input, kw)) {
+        score += Math.max(1, Math.min(kw.length / 4, 3));
+        matchedRules.push(`${taskType}:${kw}`);
+      }
+    }
+    if (score > 0) {
+      hits.push({
+        taskType: taskType as ExpertsTaskType,
+        score,
+        agent: meta.agent || rules.defaultAgent || "general",
+        heavy: meta.heavy !== false,
+      });
+    }
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  const best = hits[0];
+
+  if (!best) {
+    return {
+      taskType: (rules.defaultTaskType as ExpertsTaskType) || "development",
+      agent: rules.defaultAgent || "general-executor",
+      heavy: true,
+      pipeline: (rules.pipelines?.full_feature as ExpertsTaskType[])
+        || (rules.defaultPipeline as ExpertsTaskType[])
+        || ["explore", "planning", "development", "review"],
+      matchedRules: ["fallback-default"],
+      reason: "no keyword hit → default heavy development pipeline",
+    };
+  }
+
+  let pipelineKey = "full_feature";
+  if (best.taskType === "explore" || best.taskType === "analysis") pipelineKey = "investigation";
+  else if (best.taskType === "debug") pipelineKey = "debug";
+  else if (best.taskType === "review" || best.taskType === "testing" || best.taskType === "verification") {
+    pipelineKey = "tiny_fix";
+  } else if (input.length < 50 && best.taskType === "development") {
+    pipelineKey = "tiny_fix";
+  }
+
+  const pipeline = (rules.pipelines?.[pipelineKey] as ExpertsTaskType[])
+    || (rules.defaultPipeline as ExpertsTaskType[])
+    || [best.taskType];
+
+  return {
+    taskType: best.taskType,
+    agent: best.agent,
+    heavy: best.heavy,
+    pipeline,
+    matchedRules,
+    reason: `best=${best.taskType} score=${best.score.toFixed(1)} pipeline=${pipelineKey}`,
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/types.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/types.ts
@@ -36,6 +36,8 @@ export interface TeammateTaskLike {
   agent?: string;
   taskType?: string;
   model?: string;
+  fallbackModels?: string[];
+  thinking?: string;
   name?: string;
   [key: string]: unknown;
 }
@@ -45,6 +47,8 @@ export interface TeammateParamsLike {
   agent?: string;
   taskType?: string;
   model?: string;
+  fallbackModels?: string[];
+  thinking?: string;
   prompt?: string;
   /** P4: Maestro chain stage / command for stagePolicies. */
   stage?: string;
@@ -119,6 +123,16 @@ export interface RosterEntry {
   tools?: string[];
   /** When false, role is listed but not auto-selected. */
   enabled?: boolean;
+  /** Preferred model id (provider/model or bare). Config-only mapping; not a role name. */
+  model?: string;
+  /** Ordered fallback models for this expert. */
+  fallbackModels?: string[];
+  /** Preferred thinking level for this expert. */
+  thinking?: string;
+  /** Channel / provider prefix; bare model becomes `${channel}/${model}`. */
+  channel?: string;
+  /** Skill names this expert should load (injected as skill:// guidance). */
+  skills?: string[];
 }
 
 /** P6: in-flight expert work unit for observability. */
@@ -194,10 +208,20 @@ export interface ExpertsRules {
     viceLead?: boolean;
   };
   /**
-   * P6: project experts roster (role → agent → default taskType → tools).
+   * P6: project experts roster (role → agent → default taskType → tools / model / skills).
    * Keys are role ids; values omit id (filled from key) or include id.
    */
   roster?: Record<string, Omit<RosterEntry, "id"> & { id?: string }>;
+  /**
+   * Channel aliases: short name → provider prefix (e.g. cpa → cpa-responses).
+   * Used when roster entries set channel + bare model.
+   */
+  channels?: Record<string, string>;
+  /**
+   * Optional expertProfiles: same shape as roster values.
+   * Merged over roster keys (profiles win on conflict).
+   */
+  expertProfiles?: Record<string, Omit<RosterEntry, "id"> & { id?: string }>;
   /**
    * P7: settle → knowledge harvest policy (suggest-only by default).
    */

--- a/packages/pi-maestro-teammate/src/experts-mode/types.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/types.ts
@@ -1,0 +1,272 @@
+export type ExpertsMode = "normal" | "experts";
+
+export type ExpertsTaskType =
+  | "explore"
+  | "analysis"
+  | "debug"
+  | "development"
+  | "review"
+  | "planning"
+  | "testing"
+  | "verification";
+
+export interface TriageResult {
+  taskType: ExpertsTaskType;
+  agent: string;
+  heavy: boolean;
+  pipeline: ExpertsTaskType[];
+  matchedRules: string[];
+  reason: string;
+}
+
+export interface DispatchRecord {
+  mode: ExpertsMode;
+  taskType?: string;
+  agent?: string;
+  model?: string;
+  forced: boolean;
+  at: string;
+  promptPreview?: string;
+  /** Maestro chain stage when known (P4). */
+  stage?: string;
+}
+
+export interface TeammateTaskLike {
+  prompt?: string;
+  agent?: string;
+  taskType?: string;
+  model?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export interface TeammateParamsLike {
+  tasks?: TeammateTaskLike[];
+  agent?: string;
+  taskType?: string;
+  model?: string;
+  prompt?: string;
+  /** P4: Maestro chain stage / command for stagePolicies. */
+  stage?: string;
+  [key: string]: unknown;
+}
+
+export type GateDecision = "allow" | "ask" | "deny";
+
+/** P5: how Leader should rewrite a blocked heavy tool call. */
+export interface RewriteSuggestion {
+  action: "teammate";
+  taskType: string;
+  agent: string;
+  stage?: string;
+  prompt: string;
+  blockedTool?: string;
+  pathHint?: string;
+  commandHint?: string;
+}
+
+export interface GateResult {
+  decision: GateDecision;
+  reason: string;
+  stage?: string;
+  /** Present on deny/ask (and allowlist allow) for Leader rewrite. */
+  rewriteSuggestion?: RewriteSuggestion;
+}
+
+/** One step in a Maestro stage expert pipeline (P4). */
+export interface StagePipelineStep {
+  agent?: string;
+  taskType: ExpertsTaskType | string;
+  name?: string;
+  dependsOn?: string[];
+}
+
+/** Policy for a Maestro chain stage under Experts Mode. */
+export interface StagePolicy {
+  pipeline: StagePipelineStep[];
+  /** Paths/globs the Leader may write (documentation only unless hard-gate enforces). */
+  leaderMayWrite?: string[];
+  /** Human-readable forbid list for main-session heavy work. */
+  forbidMain?: string[];
+  /** Prefer parallel wave when multiple independent tasks (hint only). */
+  parallelism?: "serial" | "wave" | "parallel";
+  /** When true, stage should not reuse in-flight leader context for independence. */
+  independent?: boolean;
+}
+
+export interface StageExpertsPlan {
+  mode: ExpertsMode;
+  stage: string;
+  source: "stage-policy" | "triage-fallback" | "none";
+  tasks: TeammateTaskLike[];
+  leaderInstructions: string;
+  policy?: StagePolicy;
+}
+
+/** P6: one expert role on the project roster (role ≠ model). */
+export interface RosterEntry {
+  /** Stable role id (usually matches agent name or taskType). */
+  id: string;
+  /** Teammate agent / role name — never a model id. */
+  agent: string;
+  /** Default taskType for routing when stage/triage does not override. */
+  defaultTaskType: string;
+  /** Optional human label. */
+  label?: string;
+  /** Optional capability tags (explore, review, …). */
+  capabilities?: string[];
+  /** Optional tool allow hints (documentation; not enforced here). */
+  tools?: string[];
+  /** When false, role is listed but not auto-selected. */
+  enabled?: boolean;
+}
+
+/** P6: in-flight expert work unit for observability. */
+export interface InFlightExpert {
+  id: string;
+  agent?: string;
+  taskType?: string;
+  name?: string;
+  stage?: string;
+  at: string;
+  /** Optional correlation id when host provides one. */
+  correlationId?: string;
+}
+
+/** P6: lightweight canvas/status snapshot for cockpit (not a full UI). */
+export interface ExpertsCanvasSnapshot {
+  schema: "experts-canvas/1.0";
+  mode: ExpertsMode;
+  updatedAt: string;
+  activeStage: string | null;
+  leaderWaiting: boolean;
+  leaderWaitingCount: number;
+  inFlight: InFlightExpert[];
+  lastDispatch: DispatchRecord | null;
+  roster: Array<Pick<RosterEntry, "id" | "agent" | "defaultTaskType" | "label" | "enabled">>;
+  /** P7: compact pending harvest list (titles only). */
+  knowledgeSuggestions?: Array<{
+    id: string;
+    kind: KnowledgeHarvestSuggestion["kind"];
+    title: string;
+    score: number;
+    fingerprint: string;
+  }>;
+}
+
+export interface ExpertsRules {
+  version?: number;
+  defaultTaskType?: string;
+  defaultAgent?: string;
+  defaultPipeline?: string[];
+  pipelines?: Record<string, string[]>;
+  taskTypes?: Record<string, {
+    agent?: string;
+    heavy?: boolean;
+    keywords?: string[];
+  }>;
+  lightKeywords?: string[];
+  hardGate?: {
+    default?: GateDecision;
+    tools?: Record<string, GateDecision>;
+    /**
+     * P5: extra project-relative globs the Leader may write/edit under experts.
+     * Always merged with built-in orchestration defaults (report/outputs/.workflow/notes).
+     */
+    leaderAllowPaths?: string[];
+    /** P5: bash command prefixes Leader may run without teammate. */
+    bashAllowPrefixes?: string[];
+  };
+  /**
+   * P4: Maestro stage/command → expert pipeline.
+   * Keys are normalized stage names (analyze|plan|execute|review|test|debug|…).
+   */
+  stagePolicies?: Record<string, StagePolicy>;
+  /** Optional aliases: raw command/stage → stagePolicies key. */
+  stageAliases?: Record<string, string>;
+  /**
+   * P5.1: orchestrator discipline knobs for the turn reminder.
+   */
+  orchestrator?: {
+    /** stronger run-loop discipline in turn reminder (default true under experts) */
+    disciplineReminder?: boolean;
+    /** suggest workflow agent as vice-lead for multi-step pipelines (default true) */
+    viceLead?: boolean;
+  };
+  /**
+   * P6: project experts roster (role → agent → default taskType → tools).
+   * Keys are role ids; values omit id (filled from key) or include id.
+   */
+  roster?: Record<string, Omit<RosterEntry, "id"> & { id?: string }>;
+  /**
+   * P7: settle → knowledge harvest policy (suggest-only by default).
+   */
+  settle?: {
+    autoClearWaiting?: boolean;
+    /** When false, harvestKnowledgeOnSettle is a no-op. Default true. */
+    knowledgeHarvest?: boolean;
+    maxSuggestions?: number;
+    maxBodyChars?: number;
+    /**
+     * P7b: when true, deposit harvest suggestions into self-evolve pending
+     * suggestions jsonl (never promote; never runs knowledge stage here).
+     * Default false.
+     */
+    autoStage?: boolean;
+    /** Optional override for ~/.maestro/self-evolve (tests). */
+    selfEvolveOutputRoot?: string;
+  };
+}
+
+/** P7: one staged-knowhow suggestion harvested from expert settle. */
+export interface KnowledgeHarvestSuggestion {
+  id: string;
+  target: "knowhow" | "spec";
+  kind: "pitfall" | "failure-lesson" | "trade-off" | "constraint" | "knowhow";
+  title: string;
+  content: string;
+  fingerprint: string;
+  score: number;
+  agentId?: string;
+  taskType?: string;
+  stage?: string;
+  sessionId?: string;
+  runId?: string;
+  evidence: string[];
+  at: string;
+  source: "experts-settle";
+}
+
+export interface KnowledgeStageCommand {
+  argv: string[];
+  shell: string;
+  content: string;
+  suggestionId: string;
+}
+
+export interface SettleHarvestInput {
+  content?: string;
+  contents?: string[];
+  agentId?: string;
+  taskType?: string;
+  stage?: string;
+  sessionId?: string;
+  runId?: string;
+  evidenceRefs?: string[];
+  titleHint?: string;
+  /** Harvest even when mode is normal (tests). */
+  force?: boolean;
+}
+
+export interface SettleHarvestResult {
+  suggestions: KnowledgeHarvestSuggestion[];
+  skipped: Array<{ reason: string; preview?: string }>;
+  stageCommands: KnowledgeStageCommand[];
+  /** Present when rules.settle.autoStage deposited into self-evolve pool. */
+  poolDeposit?: {
+    written: number;
+    skipped: number;
+    filePath?: string;
+    ids: string[];
+  };
+}

--- a/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
@@ -1,7 +1,7 @@
 import { clearInFlight, settleInFlight } from "./inflight.ts";
 import { harvestKnowledgeOnSettle } from "./knowledge-harvest.ts";
 import { getMode, resolveStatePath } from "./mode.ts";
-import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
+import { mutateJsonStateFile, readJsonStateFile } from "./state-io.ts";
 import type { SettleHarvestResult } from "./types.ts";
 
 export interface LeaderWaitingState {
@@ -16,8 +16,8 @@ function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
 }
 
 function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
-  // M1: atomic temp+rename write for .experts-mode.json
-  writeJsonStateFile(resolveStatePath(cwd, statePath), next);
+  // M1 + MV-02: atomic write under per-file sync lock
+  mutateJsonStateFile(resolveStatePath(cwd, statePath), () => next);
 }
 
 export function getLeaderWaiting(cwd = process.cwd(), statePath?: string): LeaderWaitingState {
@@ -49,33 +49,34 @@ export function setLeaderWaiting(
   } = {},
 ): LeaderWaitingState {
   const cwd = opts.cwd ?? process.cwd();
-  const prev = readRaw(cwd, opts.statePath);
-  const prevCount = typeof prev.leaderWaitingCount === "number" ? prev.leaderWaitingCount : 0;
-  let count = prevCount;
-  if (typeof opts.activeDelta === "number") {
-    count = Math.max(0, prevCount + opts.activeDelta);
-  } else if (waiting) {
-    count = Math.max(1, prevCount || 1);
-  } else {
-    count = 0;
-  }
+  // MV-02: whole RMW under lock so concurrent dispatch/settle cannot clobber counts.
+  mutateJsonStateFile(resolveStatePath(cwd, opts.statePath), (prev) => {
+    const prevCount = typeof prev.leaderWaitingCount === "number" ? prev.leaderWaitingCount : 0;
+    let count = prevCount;
+    if (typeof opts.activeDelta === "number") {
+      count = Math.max(0, prevCount + opts.activeDelta);
+    } else if (waiting) {
+      count = Math.max(1, prevCount || 1);
+    } else {
+      count = 0;
+    }
 
-  const agentIds = opts.agentIds
-    ? opts.agentIds.map(String)
-    : Array.isArray(prev.leaderWaitingAgentIds)
-      ? (prev.leaderWaitingAgentIds as string[]).map(String)
-      : [];
+    const agentIds = opts.agentIds
+      ? opts.agentIds.map(String)
+      : Array.isArray(prev.leaderWaitingAgentIds)
+        ? (prev.leaderWaitingAgentIds as string[]).map(String)
+        : [];
 
-  const next = {
-    ...prev,
-    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
-    leaderWaiting: waiting || count > 0,
-    leaderWaitingCount: count,
-    leaderWaitingAgentIds: agentIds,
-    leaderWaitingUpdatedAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-  writeRaw(cwd, next, opts.statePath);
+    return {
+      ...prev,
+      mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
+      leaderWaiting: waiting || count > 0,
+      leaderWaitingCount: count,
+      leaderWaitingAgentIds: agentIds,
+      leaderWaitingUpdatedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  });
   return getLeaderWaiting(cwd, opts.statePath);
 }
 

--- a/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
@@ -1,8 +1,7 @@
-import fs from "node:fs";
-import path from "node:path";
 import { clearInFlight, settleInFlight } from "./inflight.ts";
 import { harvestKnowledgeOnSettle } from "./knowledge-harvest.ts";
 import { getMode, resolveStatePath } from "./mode.ts";
+import { readJsonStateFile, writeJsonStateFile } from "./state-io.ts";
 import type { SettleHarvestResult } from "./types.ts";
 
 export interface LeaderWaitingState {
@@ -13,19 +12,12 @@ export interface LeaderWaitingState {
 }
 
 function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
-  const file = resolveStatePath(cwd, statePath);
-  try {
-    if (!fs.existsSync(file)) return {};
-    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
+  return readJsonStateFile(resolveStatePath(cwd, statePath));
 }
 
 function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
-  const file = resolveStatePath(cwd, statePath);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  // M1: atomic temp+rename write for .experts-mode.json
+  writeJsonStateFile(resolveStatePath(cwd, statePath), next);
 }
 
 export function getLeaderWaiting(cwd = process.cwd(), statePath?: string): LeaderWaitingState {

--- a/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
+++ b/packages/pi-maestro-teammate/src/experts-mode/waiting.ts
@@ -1,0 +1,260 @@
+import fs from "node:fs";
+import path from "node:path";
+import { clearInFlight, settleInFlight } from "./inflight.ts";
+import { harvestKnowledgeOnSettle } from "./knowledge-harvest.ts";
+import { getMode, resolveStatePath } from "./mode.ts";
+import type { SettleHarvestResult } from "./types.ts";
+
+export interface LeaderWaitingState {
+  leaderWaiting: boolean;
+  activeCount: number;
+  updatedAt: string | null;
+  lastAgentIds: string[];
+}
+
+function readRaw(cwd: string, statePath?: string): Record<string, unknown> {
+  const file = resolveStatePath(cwd, statePath);
+  try {
+    if (!fs.existsSync(file)) return {};
+    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeRaw(cwd: string, next: Record<string, unknown>, statePath?: string): void {
+  const file = resolveStatePath(cwd, statePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+export function getLeaderWaiting(cwd = process.cwd(), statePath?: string): LeaderWaitingState {
+  const raw = readRaw(cwd, statePath);
+  const lw = raw.leaderWaiting;
+  const activeCount = typeof raw.leaderWaitingCount === "number" ? raw.leaderWaitingCount : 0;
+  const lastAgentIds = Array.isArray(raw.leaderWaitingAgentIds)
+    ? (raw.leaderWaitingAgentIds as string[]).map(String)
+    : [];
+  return {
+    leaderWaiting: lw === true || activeCount > 0,
+    activeCount,
+    updatedAt: typeof raw.leaderWaitingUpdatedAt === "string" ? raw.leaderWaitingUpdatedAt : null,
+    lastAgentIds,
+  };
+}
+
+/**
+ * Mark Leader as waiting on experts (Qoder leaderWaitingExperts analogue).
+ * activeDelta: +N when dispatching, -N when one finishes; clamp at 0.
+ */
+export function setLeaderWaiting(
+  waiting: boolean,
+  opts: {
+    cwd?: string;
+    statePath?: string;
+    activeDelta?: number;
+    agentIds?: string[];
+  } = {},
+): LeaderWaitingState {
+  const cwd = opts.cwd ?? process.cwd();
+  const prev = readRaw(cwd, opts.statePath);
+  const prevCount = typeof prev.leaderWaitingCount === "number" ? prev.leaderWaitingCount : 0;
+  let count = prevCount;
+  if (typeof opts.activeDelta === "number") {
+    count = Math.max(0, prevCount + opts.activeDelta);
+  } else if (waiting) {
+    count = Math.max(1, prevCount || 1);
+  } else {
+    count = 0;
+  }
+
+  const agentIds = opts.agentIds
+    ? opts.agentIds.map(String)
+    : Array.isArray(prev.leaderWaitingAgentIds)
+      ? (prev.leaderWaitingAgentIds as string[]).map(String)
+      : [];
+
+  const next = {
+    ...prev,
+    mode: prev.mode === "experts" || prev.mode === "normal" ? prev.mode : getMode(cwd, opts.statePath),
+    leaderWaiting: waiting || count > 0,
+    leaderWaitingCount: count,
+    leaderWaitingAgentIds: agentIds,
+    leaderWaitingUpdatedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  writeRaw(cwd, next, opts.statePath);
+  return getLeaderWaiting(cwd, opts.statePath);
+}
+
+export function clearLeaderWaiting(
+  cwd = process.cwd(),
+  opts: { statePath?: string; reason?: string } = {},
+): LeaderWaitingState {
+  const prev = readRaw(cwd, opts.statePath);
+  const next = {
+    ...prev,
+    leaderWaiting: false,
+    leaderWaitingCount: 0,
+    leaderWaitingAgentIds: [],
+    leaderWaitingUpdatedAt: new Date().toISOString(),
+    leaderWaitingClearReason: opts.reason ?? "cleared",
+    updatedAt: new Date().toISOString(),
+  };
+  writeRaw(cwd, next, opts.statePath);
+  return getLeaderWaiting(cwd, opts.statePath);
+}
+
+
+/**
+ * P3: auto-clear / decrement when an expert (teammate) settles.
+ * Prefer settledCount for batch end; agentId removes one name from the waiting list.
+ */
+export function noteExpertsSettled(
+  cwd = process.cwd(),
+  opts: {
+    statePath?: string;
+    settledCount?: number;
+    agentId?: string;
+    reason?: string;
+    /** P7: expert RESULT / summary text to harvest knowhow suggestions from. */
+    content?: string;
+    contents?: string[];
+    taskType?: string;
+    stage?: string;
+    sessionId?: string;
+    runId?: string;
+    evidenceRefs?: string[];
+    /** When false, skip harvest even if content provided. */
+    harvest?: boolean;
+  } = {},
+): LeaderWaitingState & { knowledgeHarvest?: SettleHarvestResult } {
+  const prev = getLeaderWaiting(cwd, opts.statePath);
+  if (!prev.leaderWaiting && prev.activeCount <= 0) {
+    // Still allow P7 harvest when content is provided (settle without waiting).
+    const harvestOnly = maybeHarvest(cwd, opts);
+    return harvestOnly
+      ? { ...prev, knowledgeHarvest: harvestOnly }
+      : prev;
+  }
+  const n = Math.max(1, opts.settledCount ?? 1);
+  let ids = prev.lastAgentIds.slice();
+  if (opts.agentId) {
+    const id = String(opts.agentId);
+    ids = ids.filter((x) => x !== id);
+  } else if (n >= ids.length) {
+    ids = [];
+  } else {
+    ids = ids.slice(0, Math.max(0, ids.length - n));
+  }
+  const next = setLeaderWaiting(false, {
+    cwd,
+    statePath: opts.statePath,
+    activeDelta: -n,
+    agentIds: ids,
+  });
+  // P6: drop settled experts from in-flight list.
+  try {
+    if (opts.agentId) {
+      settleInFlight(opts.agentId, { cwd, statePath: opts.statePath });
+    } else if (next.activeCount <= 0) {
+      clearInFlight(cwd, { statePath: opts.statePath });
+    } else if (prev.lastAgentIds.length) {
+      const removed = prev.lastAgentIds.filter((id) => !ids.includes(id));
+      if (removed.length) settleInFlight(removed, { cwd, statePath: opts.statePath });
+    }
+  } catch {
+    /* ignore inflight failures */
+  }
+  if (opts.reason) {
+    try {
+      const raw = readRaw(cwd, opts.statePath);
+      raw.leaderWaitingClearReason = opts.reason;
+      raw.updatedAt = new Date().toISOString();
+      writeRaw(cwd, raw, opts.statePath);
+    } catch {
+      /* ignore */
+    }
+  }
+  const knowledgeHarvest = maybeHarvest(cwd, opts);
+  const waiting = getLeaderWaiting(cwd, opts.statePath);
+  return knowledgeHarvest ? { ...waiting, knowledgeHarvest } : waiting;
+}
+
+function maybeHarvest(
+  cwd: string,
+  opts: {
+    statePath?: string;
+    agentId?: string;
+    content?: string;
+    contents?: string[];
+    taskType?: string;
+    stage?: string;
+    sessionId?: string;
+    runId?: string;
+    evidenceRefs?: string[];
+    harvest?: boolean;
+  },
+): SettleHarvestResult | undefined {
+  if (opts.harvest === false) return undefined;
+  const hasContent = Boolean(
+    (typeof opts.content === "string" && opts.content.trim())
+    || (Array.isArray(opts.contents) && opts.contents.some((c) => String(c || "").trim())),
+  );
+  if (!hasContent) return undefined;
+  try {
+    return harvestKnowledgeOnSettle(
+      {
+        content: opts.content,
+        contents: opts.contents,
+        agentId: opts.agentId,
+        taskType: opts.taskType,
+        stage: opts.stage,
+        sessionId: opts.sessionId,
+        runId: opts.runId,
+        evidenceRefs: opts.evidenceRefs,
+      },
+      { cwd, statePath: opts.statePath, record: true },
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export const EXPERTS_WAITING_START = "<!-- experts-mode-waiting:start -->";
+export const EXPERTS_WAITING_END = "<!-- experts-mode-waiting:end -->";
+
+/** Prompt fragment when Leader is waiting on active experts. */
+export function buildWaitingFragment(state: LeaderWaitingState): string {
+  if (!state.leaderWaiting) return "";
+  const ids = state.lastAgentIds.length
+    ? ` agents=[${state.lastAgentIds.slice(0, 8).join(", ")}]`
+    : "";
+  return [
+    EXPERTS_WAITING_START,
+    `<experts_mode_waiting active="${state.activeCount}"${ids}>`,
+    "Leader waiting: one or more experts (teammates) are still running.",
+    "Do not start dependent synthesis until they complete.",
+    "Use observe/wait or await the teammate-complete notification; then clear waiting by consuming results.",
+    "</experts_mode_waiting>",
+    EXPERTS_WAITING_END,
+  ].join("\n");
+}
+
+export function injectWaitingFragment(
+  systemPrompt: string,
+  state: LeaderWaitingState,
+): string {
+  const block = buildWaitingFragment(state);
+  const start = systemPrompt.indexOf(EXPERTS_WAITING_START);
+  if (!block) {
+    if (start < 0) return systemPrompt;
+    const end = systemPrompt.indexOf(EXPERTS_WAITING_END, start);
+    if (end < 0) return systemPrompt.slice(0, start).trimEnd();
+    return `${systemPrompt.slice(0, start).trimEnd()}${systemPrompt.slice(end + EXPERTS_WAITING_END.length)}`.trimEnd();
+  }
+  if (start < 0) return `${systemPrompt.trimEnd()}\n\n${block}`;
+  const end = systemPrompt.indexOf(EXPERTS_WAITING_END, start);
+  if (end < 0) return `${systemPrompt.slice(0, start).trimEnd()}\n\n${block}`;
+  return `${systemPrompt.slice(0, start).trimEnd()}\n\n${block}${systemPrompt.slice(end + EXPERTS_WAITING_END.length)}`;
+}

--- a/packages/pi-maestro-teammate/src/extension/index.ts
+++ b/packages/pi-maestro-teammate/src/extension/index.ts
@@ -193,6 +193,7 @@ import { normalizePiRetryErrorMessage } from "../runs/retry.ts";
 import { getPiSpawnCommand } from "../runs/execution-infra.ts";
 import { showMonitorOverlay, type MonitorSessionRow } from "../tui/monitor-overlay.ts";
 import { showSessionSendOverlay } from "../tui/session-send-overlay.ts";
+import { showExpertsStatusOverlay } from "../tui/experts-status-overlay.ts";
 import {
   SETTINGS_LOCALE_EVENT,
   applySettingsLocaleEvent,
@@ -265,7 +266,7 @@ import {
   syncActiveStageFromMaestro,
   formatStageBirthPacket,
   setMode,
-  formatExpertsStatusPanel,
+  formatExpertsPanel,
   EXPERTS_HARVEST_STATUS_KEY,
   expertsHarvestStatusFromCwd,
 } from "../experts-mode/index.ts";
@@ -5472,11 +5473,12 @@ export default function registerTeammateExtension(
   });
 
   pi.registerCommand("experts", {
-    description: "Experts Mode: on | off | status (default status)",
+    description: "Experts Mode: on|off|status|roster|waiting|harvest (default status)",
     async handler(args, ctx) {
       const cwd = ctx.cwd ?? process.cwd();
       const raw = (args ?? "").trim().toLowerCase();
       const sub = raw.split(/\s+/)[0] || "status";
+      const usage = "Usage: /experts [on|off|status|roster|waiting|harvest]";
       try {
         if (sub === "on") {
           setMode("experts", cwd);
@@ -5484,12 +5486,29 @@ export default function registerTeammateExtension(
         } else if (sub === "off") {
           setMode("normal", cwd);
           ctx.ui.notify("Experts Mode OFF (normal)", "info");
-        } else if (sub !== "status" && sub !== "") {
-          ctx.ui.notify("Usage: /experts [on|off|status]", "warning");
+        } else if (!["status", "roster", "waiting", "harvest", ""].includes(sub)) {
+          ctx.ui.notify(usage, "warning");
           return;
         }
-        const panel = formatExpertsStatusPanel(cwd);
-        ctx.ui.notify(panel, "info");
+
+        // Normalize view after mode toggles: on/off → full status view.
+        let view: "status" | "roster" | "waiting" | "harvest" = "status";
+        if (sub === "roster" || sub === "waiting" || sub === "harvest" || sub === "status") view = sub;
+
+        const body = formatExpertsPanel(cwd, view);
+
+        // Prefer the TUI overlay when available; notify is the fallback.
+        const canCustom = typeof ctx.ui?.custom === "function";
+        if (canCustom) {
+          try {
+            preemptCockpitResize?.();
+            await showExpertsStatusOverlay(ctx, body, `Experts · ${view}`);
+            return;
+          } catch {
+            // Overlay unavailable/failed — fall through to notify.
+          }
+        }
+        ctx.ui.notify(body, "info");
       } catch (e) {
         ctx.ui.notify(String(e), "error");
       }

--- a/packages/pi-maestro-teammate/src/extension/index.ts
+++ b/packages/pi-maestro-teammate/src/extension/index.ts
@@ -264,6 +264,8 @@ import {
   resolveMaestroStageFromWorkspace,
   syncActiveStageFromMaestro,
   formatStageBirthPacket,
+  setMode,
+  formatExpertsStatusPanel,
   EXPERTS_HARVEST_STATUS_KEY,
   expertsHarvestStatusFromCwd,
 } from "../experts-mode/index.ts";
@@ -5466,6 +5468,31 @@ export default function registerTeammateExtension(
       await showTeammateControlCenter(ctx);
       tool.description = buildTeammateToolDescription(ctx.cwd);
       pi.registerTool(tool);
+    },
+  });
+
+  pi.registerCommand("experts", {
+    description: "Experts Mode: on | off | status (default status)",
+    async handler(args, ctx) {
+      const cwd = ctx.cwd ?? process.cwd();
+      const raw = (args ?? "").trim().toLowerCase();
+      const sub = raw.split(/\s+/)[0] || "status";
+      try {
+        if (sub === "on") {
+          setMode("experts", cwd);
+          ctx.ui.notify("Experts Mode ON", "info");
+        } else if (sub === "off") {
+          setMode("normal", cwd);
+          ctx.ui.notify("Experts Mode OFF (normal)", "info");
+        } else if (sub !== "status" && sub !== "") {
+          ctx.ui.notify("Usage: /experts [on|off|status]", "warning");
+          return;
+        }
+        const panel = formatExpertsStatusPanel(cwd);
+        ctx.ui.notify(panel, "info");
+      } catch (e) {
+        ctx.ui.notify(String(e), "error");
+      }
     },
   });
 

--- a/packages/pi-maestro-teammate/src/extension/index.ts
+++ b/packages/pi-maestro-teammate/src/extension/index.ts
@@ -252,6 +252,21 @@ import {
   refreshModelRegistry,
   type TeammateTaskType,
 } from "../models/model-routing.ts";
+import {
+  ensureExpertsDispatch,
+  getMode,
+  getStatus,
+  getLeaderWaiting,
+  injectTurnReminder,
+  injectWaitingFragment,
+  loadRules,
+  noteExpertsSettled,
+  resolveMaestroStageFromWorkspace,
+  syncActiveStageFromMaestro,
+  formatStageBirthPacket,
+  EXPERTS_HARVEST_STATUS_KEY,
+  expertsHarvestStatusFromCwd,
+} from "../experts-mode/index.ts";
 import type { TeammateThinkingInput } from "../shared/thinking.ts";
 import {
   getTeammateChildToolBroker,
@@ -451,6 +466,17 @@ export default function registerTeammateExtension(
     return id.trim() ? id : undefined;
   };
 
+  /** P7b: push pending knowledgeSuggestions count into extension status for cockpit/footer. */
+  const refreshExpertsHarvestStatus = (cwd: string): void => {
+    try {
+      if (!widgetCtx?.ui || typeof widgetCtx.ui.setStatus !== "function") return;
+      const text = expertsHarvestStatusFromCwd(cwd);
+      widgetCtx.ui.setStatus(EXPERTS_HARVEST_STATUS_KEY, text || undefined);
+    } catch {
+      /* status is best-effort */
+    }
+  };
+
   const injectTeammateContext = (
     event: { systemPrompt: string },
     ctx: ExtensionContext,
@@ -461,7 +487,70 @@ export default function registerTeammateExtension(
       ? appendTaskTypeRoutingContext(withAgents, ctx.cwd, discoverAgents(ctx.cwd))
       : withAgents;
     const withDepth = appendTeammateDepthContext(withTaskType, currentDepth, currentMaxDispatchDepth);
-    return { systemPrompt: monitorInteractionModeActive ? appendMonitorModeContext(withDepth) : withDepth };
+    // Experts Mode P2/P4/P4.1: Qoder-like per-turn hard reminder + stage +
+    // waiting fragment. Stage comes from stored activeStage first (avoids a
+    // .workflow scan every turn); falls back to Maestro session.json.
+    let withExperts = withDepth;
+    try {
+      const mode = getMode(ctx.cwd);
+      const activeState = (() => {
+        try {
+          return getStatus(ctx.cwd).activeStage;
+        } catch {
+          return null;
+        }
+      })();
+      let stage = activeState?.stage;
+      let stageHint: string | undefined;
+      // P5.1: pass pipeline taskTypes/agents + rules so the reminder can
+      // add the orchestrator discipline fragment and vice-lead hint.
+      const taskTypes = activeState?.taskTypes?.filter(Boolean) || undefined;
+      const agents = activeState?.agents?.filter(Boolean) || undefined;
+      let rules: ReturnType<typeof loadRules> | undefined;
+      if (mode === "experts") {
+        try {
+          rules = loadRules();
+        } catch {
+          rules = undefined;
+        }
+        try {
+          if (!stage) {
+            // P4.1: auto-detect from Maestro session.json when not yet written.
+            const found = resolveMaestroStageFromWorkspace(ctx.cwd);
+            if (found?.stage) {
+              stage = found.stage;
+              try {
+                const plan = syncActiveStageFromMaestro(ctx.cwd);
+                if (plan) stageHint = formatStageBirthPacket(plan);
+              } catch {
+                // best-effort persist; stage is still usable
+              }
+            }
+          } else {
+            // One-line pipeline summary from stored state (no re-scan).
+            const types = (activeState?.taskTypes || []).filter(Boolean).join(" → ");
+            stageHint = `Stage \"${activeState?.stage}\" pipeline: ${types || "—"} (source=${activeState?.source || "state"}).`;
+          }
+        } catch {
+          // never break context injection
+        }
+      }
+      withExperts = injectTurnReminder(withExperts, {
+        mode,
+        cwd: ctx.cwd,
+        stage,
+        stageHint,
+        taskTypes,
+        agents,
+        rules,
+      });
+      if (mode === "experts") {
+        withExperts = injectWaitingFragment(withExperts, getLeaderWaiting(ctx.cwd));
+      }
+    } catch {
+      // never break context injection
+    }
+    return { systemPrompt: monitorInteractionModeActive ? appendMonitorModeContext(withExperts) : withExperts };
   };
 
   // =========================================================================
@@ -1896,6 +1985,16 @@ export default function registerTeammateExtension(
 
       const baseCwd = (params.cwd ?? state.baseCwd) || ctx.cwd;
       await refreshModelRegistry(ctx);
+      // Experts Mode: ensure taskType/agent before applyModelRouting (order is required).
+      // P4: pass stage from tool params / MAESTRO_STAGE so stagePolicies beat keyword triage.
+      const stageFromParams =
+        typeof (params as { stage?: unknown }).stage === "string"
+          ? String((params as { stage?: string }).stage)
+          : undefined;
+      params = ensureExpertsDispatch(params, {
+        cwd: baseCwd,
+        stage: stageFromParams,
+      }) as typeof params;
       params = applyModelRouting(
         params,
         baseCwd,
@@ -2913,10 +3012,36 @@ export default function registerTeammateExtension(
           const activeGraphMode = inferGraphMode(normalizedTasks);
           const executeGraph = async () => {
             const options = makeOptions();
-            const results = await runWithProgressFlushCleanup(
-              () => runGraph(normalizedTasks, params.concurrency ?? 4, options),
-              progressFlushGate,
-            );
+            let results: SingleResult[] | undefined;
+            try {
+              results = await runWithProgressFlushCleanup(
+                () => runGraph(normalizedTasks, params.concurrency ?? 4, options),
+                progressFlushGate,
+              );
+            } finally {
+              // P3: auto-clear leaderWaiting when multi-task graph settles (experts only).
+              // Note: runGraph path may not go through runTeammate wrapper.
+              // If runGraph throws, still settle with empty contents (best effort).
+              try {
+                if (getMode(baseCwd) === "experts" && normalizedTasks.length > 0) {
+                  noteExpertsSettled(baseCwd, {
+                    settledCount: normalizedTasks.length,
+                    reason: "extension-graph-settled",
+                    // P7: harvest from each graph result message.
+                    contents: (results ?? []).map((r) => displayMessageForResult(r)),
+                  });
+                  refreshExpertsHarvestStatus(baseCwd);
+                }
+              } catch {
+                /* ignore */
+              }
+            }
+            // runGraph threw before producing results: the exception already
+            // propagated through the finally above (waiting cleared, contents
+            // empty). This guard only satisfies the type system.
+            if (!results) {
+              throw new Error("teammate graph run failed before producing results");
+            }
 
             const hasError = results.some(resultIsError);
             const totalDur = activeGraphMode === "chain"
@@ -3112,8 +3237,23 @@ export default function registerTeammateExtension(
           if (race.done) {
             const result = race.result;
             if (!result) throw new Error("Foreground teammate finished without a result.");
-            publishSingleResult(result, false);
             const lastMessage = displayMessageForResult(result);
+            try {
+              if (getMode(baseCwd) === "experts") {
+                noteExpertsSettled(baseCwd, {
+                  settledCount: 1,
+                  agentId: result.agent || singleTask?.name || singleTask?.agent,
+                  reason: "extension-single-settled",
+                  // P7: harvest knowhow suggestions from expert RESULT (suggest-only).
+                  content: lastMessage,
+                  taskType: typeof singleTask?.taskType === "string" ? singleTask.taskType : undefined,
+                });
+                refreshExpertsHarvestStatus(baseCwd);
+              }
+            } catch {
+              /* ignore */
+            }
+            publishSingleResult(result, false);
             const details: Details = {
               mode: "single",
               results: [result],
@@ -3134,6 +3274,20 @@ export default function registerTeammateExtension(
           detached = true;
           runPromise.then((result) => {
             if (!ownsDispatchGeneration()) return;
+            try {
+              if (getMode(baseCwd) === "experts") {
+                noteExpertsSettled(baseCwd, {
+                  settledCount: 1,
+                  agentId: result.agent || singleTask?.name || singleTask?.agent,
+                  reason: "extension-single-bg-settled",
+                  content: displayMessageForResult(result),
+                  taskType: typeof singleTask?.taskType === "string" ? singleTask.taskType : undefined,
+                });
+                refreshExpertsHarvestStatus(baseCwd);
+              }
+            } catch {
+              /* ignore */
+            }
             publishSingleResult(result, true);
           }).catch((error) => {
             if (!ownsDispatchGeneration()) return;
@@ -5945,6 +6099,17 @@ export default function registerTeammateExtension(
     installMonitorEscapeTap(ctx.ui);
     setPersistentUi(ctx.ui, true);
     state.baseCwd = ctx.cwd;
+    // P7b: restore harvest status segment for cockpit footer on session start.
+    refreshExpertsHarvestStatus(ctx.cwd);
+    // P4.1: auto-inject the Maestro stage from session.json into experts state
+    // so Leaders do not need to pass stage / MAESTRO_STAGE by hand.
+    try {
+      if (getMode(ctx.cwd) === "experts") {
+        syncActiveStageFromMaestro(ctx.cwd);
+      }
+    } catch {
+      // best-effort; missing .workflow/sessions is a normal state
+    }
     // Monitor ledger + config bind to the real session cwd.
     monitorLedgerRoot = ctx.cwd;
     monitorConfig = loadMonitorConfigForRoot(ctx.cwd);

--- a/packages/pi-maestro-teammate/src/extension/index.ts
+++ b/packages/pi-maestro-teammate/src/extension/index.ts
@@ -1998,6 +1998,18 @@ export default function registerTeammateExtension(
         cwd: baseCwd,
         stage: stageFromParams,
       }) as typeof params;
+      // HV-03: if we return before spawn, reverse the waiting +N reserved above.
+      const settleReservedWaiting = (reason: string): void => {
+        try {
+          const meta = (params as { __experts?: { waitingDelta?: number } }).__experts;
+          const delta = typeof meta?.waitingDelta === "number" ? meta.waitingDelta : 0;
+          if (delta > 0 && getMode(baseCwd) === "experts") {
+            noteExpertsSettled(baseCwd, { settledCount: delta, reason });
+          }
+        } catch {
+          /* ignore */
+        }
+      };
       params = applyModelRouting(
         params,
         baseCwd,
@@ -2009,6 +2021,7 @@ export default function registerTeammateExtension(
       // --- Normalize to task list (shared with the child proxy path) ---
       const normalization = normalizeTeammateParams(params);
       if (normalization.error) {
+        settleReservedWaiting("extension-normalize-error");
         return {
           content: [{ type: "text", text: normalization.error }],
           isError: true,
@@ -2019,6 +2032,7 @@ export default function registerTeammateExtension(
       const normalizedTasks = normalization.tasks;
       const budget = checkActiveAgentBudget(state, normalizedTasks.length);
       if (!budget.allowed) {
+        settleReservedWaiting("extension-budget-exhausted");
         return {
           content: [{
             type: "text",

--- a/packages/pi-maestro-teammate/src/extension/index.ts
+++ b/packages/pi-maestro-teammate/src/extension/index.ts
@@ -5473,12 +5473,12 @@ export default function registerTeammateExtension(
   });
 
   pi.registerCommand("experts", {
-    description: "Experts Mode: on|off|status|roster|waiting|harvest (default status)",
+    description: "Experts Mode: on|off|status|roster|config|waiting|harvest (default status)",
     async handler(args, ctx) {
       const cwd = ctx.cwd ?? process.cwd();
       const raw = (args ?? "").trim().toLowerCase();
       const sub = raw.split(/\s+/)[0] || "status";
-      const usage = "Usage: /experts [on|off|status|roster|waiting|harvest]";
+      const usage = "Usage: /experts [on|off|status|roster|config|waiting|harvest]";
       try {
         if (sub === "on") {
           setMode("experts", cwd);
@@ -5486,14 +5486,16 @@ export default function registerTeammateExtension(
         } else if (sub === "off") {
           setMode("normal", cwd);
           ctx.ui.notify("Experts Mode OFF (normal)", "info");
-        } else if (!["status", "roster", "waiting", "harvest", ""].includes(sub)) {
+        } else if (!["status", "roster", "config", "waiting", "harvest", ""].includes(sub)) {
           ctx.ui.notify(usage, "warning");
           return;
         }
 
         // Normalize view after mode toggles: on/off → full status view.
+        // `config` is an alias of `roster` (shows model/channel/skills profiles).
         let view: "status" | "roster" | "waiting" | "harvest" = "status";
-        if (sub === "roster" || sub === "waiting" || sub === "harvest" || sub === "status") view = sub;
+        if (sub === "roster" || sub === "config") view = "roster";
+        else if (sub === "waiting" || sub === "harvest" || sub === "status") view = sub;
 
         const body = formatExpertsPanel(cwd, view);
 

--- a/packages/pi-maestro-teammate/src/extension/teammate-proxy.ts
+++ b/packages/pi-maestro-teammate/src/extension/teammate-proxy.ts
@@ -8,6 +8,11 @@
 
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import {
+  ensureExpertsDispatch,
+  getMode,
+  noteExpertsSettled,
+} from "../experts-mode/index.ts";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
@@ -918,8 +923,29 @@ export async function handleProxyRequest(
         return parent?.resolvedModel ?? parent?.requestedModel;
       })();
       const dispatchOriginCwd = state.baseCwd || process.cwd();
+      // MV-03: mirror root path — stage/triage/profiles before model routing.
+      const stageFromParams =
+        typeof (p as { stage?: unknown }).stage === "string"
+          ? String((p as { stage?: string }).stage)
+          : undefined;
+      const prepared = ensureExpertsDispatch(p, {
+        cwd: dispatchOriginCwd,
+        stage: stageFromParams,
+      }) as typeof p & { __experts?: { waitingDelta?: number } };
+      const settleReservedWaiting = (reason: string): void => {
+        try {
+          const delta = typeof prepared.__experts?.waitingDelta === "number"
+            ? prepared.__experts.waitingDelta
+            : 0;
+          if (delta > 0 && getMode(dispatchOriginCwd) === "experts") {
+            noteExpertsSettled(dispatchOriginCwd, { settledCount: delta, reason });
+          }
+        } catch {
+          /* ignore */
+        }
+      };
       const routedParams = applyModelRouting(
-        p,
+        prepared,
         dispatchOriginCwd,
         modelCapabilities.map((model) => model.id),
         undefined,
@@ -930,6 +956,7 @@ export async function handleProxyRequest(
       // the routing authority because the child catalog can be stale or scoped.
       const normalization = normalizeTeammateParams(routedParams);
       if (normalization.error) {
+        settleReservedWaiting("proxy-normalize-error");
         abandonPendingProxyDispatch();
         reply({ type: "teammate_proxy_result", requestId, result: {
           content: [{ type: "text", text: normalization.error }],
@@ -940,6 +967,7 @@ export async function handleProxyRequest(
       const allTasks = normalization.tasks;
       const budget = checkActiveAgentBudget(state, allTasks.length);
       if (!budget.allowed) {
+        settleReservedWaiting("proxy-budget-exhausted");
         abandonPendingProxyDispatch();
         reply({ type: "teammate_proxy_result", requestId, result: {
           content: [{
@@ -1836,15 +1864,45 @@ export async function handleProxyRequest(
       });
       else installNestedColdRestart(activeAgent, singleTask);
 
+      const settleProxyWaiting = (
+        reason: string,
+        contents?: string[],
+        agentId?: string,
+      ): void => {
+        try {
+          const delta = typeof prepared.__experts?.waitingDelta === "number"
+            ? prepared.__experts.waitingDelta
+            : 0;
+          if (delta > 0 && getMode(dispatchOriginCwd) === "experts") {
+            noteExpertsSettled(dispatchOriginCwd, {
+              settledCount: delta,
+              reason,
+              contents,
+              agentId,
+            });
+          }
+        } catch {
+          /* ignore */
+        }
+      };
+
       const executeNested = async () => {
         if (normalizedTasks) {
           const mode = inferGraphMode(normalizedTasks);
-          let results: SingleResult[];
+          let results: SingleResult[] | undefined;
           try {
             results = await runGraph(normalizedTasks, p.concurrency ?? 4, runOpts);
           } finally {
+            // MV-03 / HV-03: settle waiting reserved by ensureExpertsDispatch.
+            settleProxyWaiting(
+              "proxy-graph-settled",
+              (results ?? []).map((r) => displayMessageForResult(r)),
+            );
             proxyProgressFlushGate?.flush();
             proxyProgressFlushGate?.dispose();
+          }
+          if (!results) {
+            throw new Error("proxy nested graph failed before producing results");
           }
           const hasError = results.some(resultIsError);
           const summaries = summarizeGraphResults(results, normalizedTasks);
@@ -1902,7 +1960,19 @@ export async function handleProxyRequest(
           };
         }
 
-        const result = await runSingleTeammate(singleRunParams, runOpts);
+        let result: SingleResult | undefined;
+        try {
+          result = await runSingleTeammate(singleRunParams, runOpts);
+        } finally {
+          settleProxyWaiting(
+            "proxy-single-settled",
+            result ? [displayMessageForResult(result)] : undefined,
+            result?.agent || singleTask?.name || singleTask?.agent,
+          );
+          proxyProgressFlushGate?.flush();
+          proxyProgressFlushGate?.dispose();
+        }
+        if (!result) throw new Error("proxy nested single run failed before producing a result");
         const lastMsg = displayMessageForResult(result);
         return {
           resultPayload: {

--- a/packages/pi-maestro-teammate/src/runs/execution.ts
+++ b/packages/pi-maestro-teammate/src/runs/execution.ts
@@ -28,6 +28,7 @@ import type {
 } from "../shared/types.ts";
 import { wrapLeasedMessage, type LeaseToken } from "./session-handoff.ts";
 import { applyModelRouting, syncModelCircuitPolicies, type TeammateTaskType } from "../models/model-routing.ts";
+import { ensureExpertsDispatch, noteExpertsSettled, getMode } from "../experts-mode/index.ts";
 import type { TeammateModelCapability } from "../models/model-catalog.ts";
 import {
   rankModelsByHealth,
@@ -2401,13 +2402,37 @@ export async function runGraph(
   return results;
 }
 
+/** Best-effort result text for experts settle harvest (avoids teammate-core cycle). */
+function resultTextForHarvest(result: SingleResult): string {
+  const last = result.messages.at(-1)?.content;
+  if (typeof last === "string" && last.trim()) return last;
+  if (result.structuredOutput !== undefined) {
+    try {
+      return `[structured_output] ${JSON.stringify(result.structuredOutput)}`;
+    } catch {
+      // non-serializable value — fall through
+    }
+  }
+  return "(no output)";
+}
+
 /** Programmatic tasks-only entry point matching the public teammate schema. */
 export async function runTeammate(
   params: RunTeammateParams,
   options: RunTeammateOptions,
 ): Promise<SingleResult[]> {
+  // Experts Mode: force taskType/agent before model routing (never hardcode models).
+  // P4: honor params.stage / MAESTRO_STAGE for stagePolicies.
+  const stageFromParams =
+    typeof (params as { stage?: unknown }).stage === "string"
+      ? String((params as { stage?: string }).stage)
+      : undefined;
+  const prepared = ensureExpertsDispatch(params, {
+    cwd: options.baseCwd,
+    stage: stageFromParams,
+  }) as RunTeammateParams;
   const routed = applyModelRouting(
-    params,
+    prepared,
     options.baseCwd,
     options.modelCapabilities?.map((capability) => capability.id) ?? [],
     undefined,
@@ -2419,7 +2444,26 @@ export async function runTeammate(
   syncModelCircuitPolicies(options.modelCircuitBreaker ?? sharedModelCircuitBreaker, options.baseCwd);
   const normalized = normalizeTeammateParams(routed);
   if (normalized.error) throw new Error(normalized.error);
-  return runGraph(normalized.tasks, params.concurrency ?? 4, options);
+  const taskCount = normalized.tasks.length;
+  let results: SingleResult[] | undefined;
+  try {
+    results = await runGraph(normalized.tasks, params.concurrency ?? 4, options);
+    return results;
+  } finally {
+    // P3: auto-clear / decrement leaderWaiting when the graph settles (experts mode only).
+    try {
+      if (getMode(options.baseCwd) === "experts" && taskCount > 0) {
+        noteExpertsSettled(options.baseCwd, {
+          settledCount: taskCount,
+          reason: "runTeammate-settled",
+          // P7: best-effort harvest text from each result (empty when graph throws).
+          contents: (results ?? []).map((r) => resultTextForHarvest(r)),
+        });
+      }
+    } catch {
+      // never fail the run on waiting bookkeeping
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-maestro-teammate/src/runs/execution.ts
+++ b/packages/pi-maestro-teammate/src/runs/execution.ts
@@ -2430,7 +2430,11 @@ export async function runTeammate(
   const prepared = ensureExpertsDispatch(params, {
     cwd: options.baseCwd,
     stage: stageFromParams,
-  }) as RunTeammateParams;
+  }) as RunTeammateParams & { __experts?: { waitingDelta?: number } };
+  // HV-03: reserved waiting slots must always be settled, even on normalize failure.
+  const reservedWaiting = typeof prepared.__experts?.waitingDelta === "number"
+    ? prepared.__experts.waitingDelta
+    : 0;
   const routed = applyModelRouting(
     prepared,
     options.baseCwd,
@@ -2443,18 +2447,17 @@ export async function runTeammate(
   // role's mapped model before any acquisition happens.
   syncModelCircuitPolicies(options.modelCircuitBreaker ?? sharedModelCircuitBreaker, options.baseCwd);
   const normalized = normalizeTeammateParams(routed);
-  if (normalized.error) throw new Error(normalized.error);
-  const taskCount = normalized.tasks.length;
   let results: SingleResult[] | undefined;
   try {
+    if (normalized.error) throw new Error(normalized.error);
     results = await runGraph(normalized.tasks, params.concurrency ?? 4, options);
     return results;
   } finally {
-    // P3: auto-clear / decrement leaderWaiting when the graph settles (experts mode only).
+    // P3 + HV-03: settle reserved waiting (success, graph throw, or normalize error).
     try {
-      if (getMode(options.baseCwd) === "experts" && taskCount > 0) {
+      if (getMode(options.baseCwd) === "experts" && reservedWaiting > 0) {
         noteExpertsSettled(options.baseCwd, {
-          settledCount: taskCount,
+          settledCount: reservedWaiting,
           reason: "runTeammate-settled",
           // P7: best-effort harvest text from each result (empty when graph throws).
           contents: (results ?? []).map((r) => resultTextForHarvest(r)),

--- a/packages/pi-maestro-teammate/src/tui/experts-status-overlay.ts
+++ b/packages/pi-maestro-teammate/src/tui/experts-status-overlay.ts
@@ -1,0 +1,137 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+/**
+ * Read-only Experts Mode status panel overlay.
+ *
+ * Rendered through ctx.ui.custom as a centered modal (NOT the full teammate
+ * control center): a bordered text box showing pre-formatted panel lines.
+ * Closes on Esc / q / Q / Enter; arrow keys and PgUp/PgDn scroll long bodies.
+ * The body is produced by the pure formatters in experts-mode/status-panel.ts,
+ * so this overlay never reads state or prints model ids itself.
+ */
+
+/** Structural slice of the host Theme we use; null → plain box fallback. */
+export interface ExpertsStatusOverlayThemeLike {
+  fg(color: string, text: string): string;
+  bg(color: string, text: string): string;
+}
+
+const VISIBLE_HEIGHT = 24;
+
+export class ExpertsStatusOverlay {
+  private readonly lines: string[];
+  private scrollOffset = 0;
+  private requestRender: () => void = () => {};
+
+  constructor(
+    body: string,
+    private readonly title: string,
+    private readonly theme: ExpertsStatusOverlayThemeLike | null,
+    private readonly close: () => void,
+  ) {
+    this.lines = body.split("\n");
+  }
+
+  setRequestRender(fn: () => void): void {
+    this.requestRender = fn;
+  }
+
+  private get maxScrollOffset(): number {
+    return Math.max(0, this.lines.length - VISIBLE_HEIGHT);
+  }
+
+  render(width: number): string[] {
+    const inner = Math.max(1, width - 4);
+    const dim = (value: string): string =>
+      this.theme ? this.theme.fg("dim", value) : `\x1b[2m${value}\x1b[0m`;
+    const accent = (value: string): string =>
+      this.theme ? this.theme.fg("accent", value) : `\x1b[36m${value}\x1b[0m`;
+    const border = (glyph: string): string =>
+      this.theme ? this.theme.bg("customMessageBg", this.theme.fg("borderMuted", glyph)) : glyph;
+    const fill = (line: string): string => {
+      const fitted = truncateToWidth(line, inner, "…");
+      return `${dim("|")} ${fitted}${" ".repeat(Math.max(0, inner - visibleWidth(fitted)))} ${dim("|")}`;
+    };
+
+    const out: string[] = [border(`╭${"─".repeat(inner)}╮`)];
+    out.push(fill(accent(` ${this.title} `)));
+
+    const long = this.lines.length > VISIBLE_HEIGHT;
+    const visible = long
+      ? this.lines.slice(this.scrollOffset, this.scrollOffset + VISIBLE_HEIGHT)
+      : this.lines;
+    for (const line of visible) out.push(fill(line === "" ? " " : line));
+
+    out.push(fill(""));
+    out.push(fill(long
+      ? dim(`Esc / q / Enter close · ↑↓ scroll · ${this.scrollOffset + 1}-${this.scrollOffset + visible.length}/${this.lines.length}`)
+      : dim("Esc / q / Enter close")));
+    out.push(border(`╰${"─".repeat(inner)}╯`));
+    return out;
+  }
+
+  handleInput(data: string): void {
+    // Esc / q / Q / Enter / Ctrl-C close the panel.
+    if (data === "\x1b" || data === "q" || data === "Q" || data === "\r" || data === "\n" || data === "\x03") {
+      this.close();
+      return;
+    }
+    if (data === "\x1b[A" || data === "k") {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+    } else if (data === "\x1b[B" || data === "j") {
+      this.scrollOffset = Math.min(this.maxScrollOffset, this.scrollOffset + 1);
+    } else if (data === "\x1b[5~") {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 10);
+    } else if (data === "\x1b[6~") {
+      this.scrollOffset = Math.min(this.maxScrollOffset, this.scrollOffset + 10);
+    } else {
+      return;
+    }
+    this.requestRender();
+  }
+
+  invalidate(): void {}
+  dispose(): void {}
+}
+
+export interface ExpertsStatusOverlayCtx {
+  ui: { custom: Function };
+  cwd?: string;
+}
+
+/**
+ * Show a read-only Experts status panel as a centered modal overlay.
+ * Resolves when the user closes it (Esc/q/Enter). When the host has no
+ * interactive custom overlay, the caller falls back to ctx.ui.notify.
+ */
+export async function showExpertsStatusOverlay(
+  ctx: ExpertsStatusOverlayCtx,
+  body: string,
+  title = "Experts",
+): Promise<void> {
+  return ctx.ui.custom(
+    (
+      tui: { requestRender: () => void },
+      theme: unknown,
+      _keybindings: unknown,
+      done: (result: undefined) => void,
+    ) => {
+      const themeLike = (
+        theme
+        && typeof (theme as { fg?: unknown }).fg === "function"
+        && typeof (theme as { bg?: unknown }).bg === "function"
+      )
+        ? theme as ExpertsStatusOverlayThemeLike
+        : null;
+      const overlay = new ExpertsStatusOverlay(body, title, themeLike, () => done(undefined));
+      overlay.setRequestRender(() => tui.requestRender());
+      return {
+        render: (width: number) => overlay.render(width),
+        handleInput: (data: string) => overlay.handleInput(data),
+        invalidate: () => overlay.invalidate(),
+        dispose: () => overlay.dispose(),
+      };
+    },
+    { overlay: true, overlayOptions: { anchor: "center", width: "90%", maxHeight: "85%" } },
+  );
+}

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -1,0 +1,1171 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import {
+  classifyIntent,
+  ensureExpertsDispatch,
+  evaluateHardGate,
+  getMode,
+  setMode,
+  buildTurnReminder,
+  injectTurnReminder,
+  setLeaderWaiting,
+  clearLeaderWaiting,
+  getLeaderWaiting,
+  getStatus,
+  formatExpertResult,
+  parseExpertResultAgentId,
+  noteExpertsSettled,
+  type TeammateParamsLike,
+} from "../src/experts-mode/index.ts";
+
+function tempCwd(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "experts-mode-wire-"));
+}
+
+test("ensureExpertsDispatch fills taskType only in experts mode", () => {
+  // P4.1/P5.1: host may export MAESTRO_STAGE=execute which would force development
+  // over keyword triage — isolate env for this keyword-only assertion.
+  withCleanMaestroEnv(() => {
+    const cwd = tempCwd();
+    const params: TeammateParamsLike = {
+      tasks: [{ prompt: "搜索 PositionManager 调用链" }],
+    };
+
+    const normal = ensureExpertsDispatch(params, { cwd, mode: "normal", record: false });
+    assert.equal(normal.tasks?.[0]?.taskType, undefined);
+
+    setMode("experts", cwd);
+    const experts = ensureExpertsDispatch(params, { cwd, mode: "experts", record: false });
+    assert.equal(experts.tasks?.[0]?.taskType, "explore");
+    assert.equal(experts.tasks?.[0]?.agent, "explorer");
+    assert.equal(experts.__experts?.forced, true);
+  });
+});
+
+test("ensureExpertsDispatch does not override explicit taskType", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const kept = ensureExpertsDispatch({
+    tasks: [{ prompt: "anything", taskType: "testing", agent: "general" }],
+  }, { cwd, mode: "experts", record: false });
+  assert.equal(kept.tasks?.[0]?.taskType, "testing");
+  assert.equal(kept.tasks?.[0]?.agent, "general");
+});
+
+test("ensureExpertsDispatch does not set model (routing owns models)", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const out = ensureExpertsDispatch({
+    tasks: [{ prompt: "实现 JWT middleware 并改代码" }],
+  } as TeammateParamsLike, { cwd, mode: "experts", record: false });
+  assert.equal(out.tasks?.[0]?.taskType, "development");
+  assert.equal(out.tasks?.[0]?.model, undefined);
+});
+
+test("hard-gate denies write under experts (P5), allows under normal", () => {
+  const cwd = tempCwd();
+  assert.equal(evaluateHardGate("write", { cwd, mode: "normal" }).decision, "allow");
+  // Business path write is denied for Leader under experts (P5 strict).
+  const denied = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    toolInput: { path: "src/app.ts" },
+    stage: "execute",
+  });
+  assert.equal(denied.decision, "deny");
+  assert.ok(denied.rewriteSuggestion?.taskType);
+  assert.equal(evaluateHardGate("teammate", { cwd, mode: "experts" }).decision, "allow");
+});
+
+test("classifyIntent maps planning and debug", () => {
+  assert.equal(classifyIntent("设计 Experts Mode 架构方案").taskType, "planning");
+  assert.equal(classifyIntent("这个 bug 报错 stack 怎么调试").taskType, "debug");
+});
+
+test("mode state persists under cwd", () => {
+  const cwd = tempCwd();
+  assert.equal(getMode(cwd), "normal");
+  setMode("experts", cwd);
+  assert.equal(getMode(cwd), "experts");
+  assert.ok(fs.existsSync(path.join(cwd, ".experts-mode.json")));
+});
+
+test("source wiring: runTeammate and teammate tool call ensure before routing", () => {
+  // Static contract: patch must keep this order in monorepo sources.
+  const execution = fs.readFileSync(
+    path.resolve("src/runs/execution.ts"),
+    "utf8",
+  );
+  const extension = fs.readFileSync(
+    path.resolve("src/extension/index.ts"),
+    "utf8",
+  );
+  const preparedIdx = execution.indexOf("const prepared = ensureExpertsDispatch");
+  const routeIdx = execution.indexOf("applyModelRouting(", preparedIdx);
+  assert.ok(preparedIdx > 0, "runTeammate must call ensureExpertsDispatch");
+  assert.ok(routeIdx > preparedIdx, "runTeammate must applyModelRouting after ensure");
+  assert.ok(
+    execution.slice(routeIdx, routeIdx + 80).includes("prepared"),
+    "applyModelRouting must receive prepared params",
+  );
+
+  const ensureIdx = extension.indexOf("params = ensureExpertsDispatch");
+  const applyIdx = extension.indexOf("params = applyModelRouting", ensureIdx);
+  assert.ok(ensureIdx > 0, "teammate tool must call ensureExpertsDispatch");
+  assert.ok(applyIdx > ensureIdx, "teammate tool must applyModelRouting after ensure");
+});
+
+// --- G4 team-worker taskType force (frontmatter + spawn templates) ---
+import { resolveAgent } from "../src/agents/agents.ts";
+
+const TEAM_SKILLS = [
+  "team-arch-opt",
+  "team-coordinate",
+  "team-issue",
+  "team-lifecycle-v4",
+  "team-perf-opt",
+  "team-review",
+  "team-swarm",
+  "team-testing",
+];
+
+test("G4 team-worker frontmatter taskType reaches resolveAgent", () => {
+  // applyModelRouting falls back to resolveAgent(cwd, agent).taskType when the
+  // spawn omits taskType; the team-worker agent must carry a development default
+  // so team skill spawns never skip teammate-models routing.
+  const agent = resolveAgent(process.cwd(), "team-worker");
+  assert.ok(agent, "team-worker must be discoverable from repo cwd");
+  assert.equal(agent!.taskType, "development");
+});
+
+test("G4 team skill spawn templates carry taskType at top and task level", () => {
+  const expected = 'teammate({ agent: "team-worker", taskType: "development", tasks: [{ name: ';
+  for (const skill of TEAM_SKILLS) {
+    const file = path.resolve(`../../.pi/skills/${skill}/SKILL.md`);
+    assert.ok(fs.existsSync(file), `${skill}/SKILL.md must exist`);
+    const content = fs.readFileSync(file, "utf8");
+    const matches = content.split(expected).length - 1;
+    // team-issue documents serial + parallel spawns; others at least one.
+    assert.equal(matches, skill === "team-issue" ? 2 : 1, `${skill} must carry taskType on every team-worker spawn`);
+  }
+});
+
+test("G4 team-worker.md frontmatter declares taskType: development", () => {
+  const file = path.resolve("../../.pi/agents/team-worker.md");
+  assert.ok(fs.existsSync(file), "team-worker.md must exist");
+  const frontmatter = fs.readFileSync(file, "utf8").split("---")[1] ?? "";
+  assert.match(frontmatter, /taskType:\s*development/);
+});
+
+// --- G5 hard-deny probe (UNPROVEN cell -> PROVEN at library + adapter) ---
+test("G5 hard-deny probe: write src/hard-deny-probe.ts denied with rewrite", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const gate = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    stage: "execute",
+    toolInput: { path: "src/hard-deny-probe.ts", content: "export const x = 1;" },
+  });
+  assert.equal(gate.decision, "deny");
+  assert.ok(gate.rewriteSuggestion, "deny must carry rewriteSuggestion");
+  assert.equal(gate.rewriteSuggestion!.action, "teammate");
+  assert.equal(gate.rewriteSuggestion!.taskType, "development");
+  assert.equal(gate.rewriteSuggestion!.agent, "general-executor");
+  assert.ok(String(gate.rewriteSuggestion!.pathHint).includes("hard-deny-probe.ts"));
+  // Same probe outside experts mode must allow (control).
+  assert.equal(evaluateHardGate("write", { cwd, mode: "normal", toolInput: { path: "src/hard-deny-probe.ts" } }).decision, "allow");
+});
+
+test("G5 adapter contract: pi-adapter deny branch returns block:true with rewrite", () => {
+  // Static contract (same style as source wiring): the host adapter must turn a
+  // hard-gate deny into a blocking pre-tool result carrying teammate rewrite.
+  const adapter = fs.readFileSync(
+    path.resolve("../pi-maestro-flow/src/hooks/pi-adapter.ts"),
+    "utf8",
+  );
+  const denyIdx = adapter.indexOf('gate.decision === "deny"');
+  assert.ok(denyIdx > 0, "pi-adapter must branch on hard-gate deny");
+  const branch = adapter.slice(denyIdx, denyIdx + 500);
+  assert.ok(branch.includes("block: true"), "deny branch must return block:true");
+  assert.ok(branch.includes("reason"), "deny branch must return a reason");
+  assert.ok(branch.includes("rewrite"), "deny branch must embed teammate rewrite guidance");
+  const callIdx = adapter.indexOf("evaluateHardGate(event.toolName");
+  assert.ok(callIdx > 0 && callIdx < denyIdx, "adapter must call evaluateHardGate before the deny branch");
+});
+
+
+test("P2-1 buildTurnReminder only in experts mode", () => {
+  assert.equal(buildTurnReminder("normal"), "");
+  const r = buildTurnReminder("experts");
+  assert.match(r, /experts_mode_reminder/);
+  assert.match(r, /taskType/);
+  assert.match(r, /Do NOT hardcode model/);
+  const injected = injectTurnReminder("BASE PROMPT", { mode: "experts" });
+  assert.match(injected, /BASE PROMPT/);
+  assert.match(injected, /experts_mode_reminder/);
+  const stripped = injectTurnReminder(injected, { mode: "normal" });
+  assert.ok(!stripped.includes("experts_mode_reminder"));
+});
+
+test("P2-2 leader waiting state machine", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  assert.equal(getLeaderWaiting(cwd).leaderWaiting, false);
+  setLeaderWaiting(true, { cwd, activeDelta: 2, agentIds: ["a", "b"] });
+  let w = getLeaderWaiting(cwd);
+  assert.equal(w.leaderWaiting, true);
+  assert.equal(w.activeCount, 2);
+  setLeaderWaiting(true, { cwd, activeDelta: -1 });
+  w = getLeaderWaiting(cwd);
+  assert.equal(w.activeCount, 1);
+  clearLeaderWaiting(cwd, { reason: "test-done" });
+  w = getLeaderWaiting(cwd);
+  assert.equal(w.leaderWaiting, false);
+  assert.equal(w.activeCount, 0);
+  const st = getStatus(cwd);
+  assert.equal(st.leaderWaiting, false);
+});
+
+test("P2-2 ensureExpertsDispatch sets leaderWaiting", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  ensureExpertsDispatch({ tasks: [{ prompt: "实现 feature X", name: "dev-1" }] }, { cwd, mode: "experts", record: true });
+  assert.equal(getLeaderWaiting(cwd).leaderWaiting, true);
+  assert.ok(getLeaderWaiting(cwd).activeCount >= 1);
+});
+
+test("P2-3 formatExpertResult envelope", () => {
+  const text = formatExpertResult({
+    agentId: "abc-123",
+    agentName: "Lee",
+    content: "done work",
+    taskType: "development",
+    exitCode: 0,
+  });
+  assert.match(text, /Agent Lee has completed/);
+  assert.match(text, /agentId: abc-123/);
+  assert.match(text, /--- RESULT ---/);
+  assert.match(text, /done work/);
+  assert.equal(parseExpertResultAgentId(text), "abc-123");
+  const again = formatExpertResult({ agentId: "x", content: text, skipIfPresent: true });
+  assert.ok(again.includes("--- RESULT ---"));
+  // should not double-wrap
+  assert.equal(again.match(/--- RESULT ---/g)?.length, 1);
+});
+
+test("P2-4 role is not model — ensure never assigns model", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const out = ensureExpertsDispatch({
+    tasks: [{ prompt: "实现 JWT middleware 并改代码", agent: "general-executor" }],
+  } as TeammateParamsLike, { cwd, mode: "experts", record: false });
+  assert.equal(out.tasks?.[0]?.taskType, "development");
+  assert.equal(out.tasks?.[0]?.agent, "general-executor");
+  assert.equal(out.tasks?.[0]?.model, undefined);
+  // agent name must not look like provider/model
+  assert.ok(!String(out.tasks?.[0]?.agent).includes("/"));
+});
+
+test("P3 noteExpertsSettled decrements and clears at zero", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  setLeaderWaiting(true, { cwd, activeDelta: 2, agentIds: ["a", "b"] });
+  noteExpertsSettled(cwd, { settledCount: 1, agentId: "a", reason: "one-done" });
+  let w = getLeaderWaiting(cwd);
+  assert.equal(w.activeCount, 1);
+  assert.equal(w.leaderWaiting, true);
+  assert.ok(!w.lastAgentIds.includes("a"));
+  noteExpertsSettled(cwd, { settledCount: 1, reason: "two-done" });
+  w = getLeaderWaiting(cwd);
+  assert.equal(w.activeCount, 0);
+  assert.equal(w.leaderWaiting, false);
+});
+
+test("P3 noteExpertsSettled is no-op when not waiting", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const before = getLeaderWaiting(cwd);
+  const after = noteExpertsSettled(cwd, { settledCount: 3, reason: "noop" });
+  assert.equal(after.activeCount, before.activeCount);
+  assert.equal(after.leaderWaiting, false);
+});
+
+test("P3 source wiring: runTeammate finally notes settle", () => {
+  const execution = fs.readFileSync(path.resolve("src/runs/execution.ts"), "utf8");
+  assert.ok(execution.includes("noteExpertsSettled"), "runTeammate must call noteExpertsSettled");
+  assert.ok(execution.includes("runTeammate-settled"), "must use settle reason");
+  const extension = fs.readFileSync(path.resolve("src/extension/index.ts"), "utf8");
+  assert.ok(extension.includes("extension-graph-settled") || extension.includes("noteExpertsSettled"));
+  assert.ok(extension.includes("extension-single-settled"));
+});
+
+
+// --- P4 Stage Experts Policy ---
+import {
+  resolveStageExpertsPlan,
+  resolveStageName,
+  getStagePolicy,
+  primaryStageAssignment,
+  clearRulesCache,
+} from "../src/experts-mode/index.ts";
+
+test("P4 resolveStageName aliases maestro-execute → execute", () => {
+  clearRulesCache();
+  assert.equal(resolveStageName("maestro-execute"), "execute");
+  assert.equal(resolveStageName("quality-review"), "review");
+  assert.equal(resolveStageName("analyze-macro"), "analyze");
+});
+
+test("P4 getStagePolicy returns execute development pipeline", () => {
+  clearRulesCache();
+  const found = getStagePolicy("execute");
+  assert.ok(found);
+  assert.equal(found!.stage, "execute");
+  assert.equal(found!.policy.pipeline[0]?.taskType, "development");
+});
+
+test("P4 resolveStageExpertsPlan empty in normal mode", () => {
+  const cwd = tempCwd();
+  setMode("normal", cwd);
+  clearRulesCache();
+  const plan = resolveStageExpertsPlan("execute", "实现 JWT", { cwd, mode: "normal", record: false });
+  assert.equal(plan.mode, "normal");
+  assert.equal(plan.tasks.length, 0);
+  assert.equal(plan.source, "none");
+});
+
+test("P4 resolveStageExpertsPlan uses stagePolicies for analyze", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const plan = resolveStageExpertsPlan("analyze", "理解认证流程", { cwd, mode: "experts", record: true });
+  assert.equal(plan.mode, "experts");
+  assert.equal(plan.source, "stage-policy");
+  assert.equal(plan.stage, "analyze");
+  assert.equal(plan.tasks.length, 2);
+  assert.equal(plan.tasks[0]?.taskType, "explore");
+  assert.equal(plan.tasks[0]?.agent, "explorer");
+  assert.equal(plan.tasks[1]?.taskType, "analysis");
+  assert.equal(plan.tasks[1]?.agent, "analyst");
+  assert.ok(Array.isArray(plan.tasks[1]?.dependsOn));
+  assert.ok(plan.leaderInstructions.includes("stage=\"analyze\""));
+  const status = getStatus(cwd);
+  assert.equal(status.activeStage?.stage, "analyze");
+});
+
+test("P4 ensureExpertsDispatch stage beats keyword triage", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  // Prompt looks like explore, but stage=execute must force development
+  const out = ensureExpertsDispatch(
+    { tasks: [{ prompt: "搜索 PositionManager 调用链" }] } as TeammateParamsLike,
+    { cwd, mode: "experts", record: false, stage: "execute" },
+  );
+  assert.equal(out.tasks?.[0]?.taskType, "development");
+  assert.equal(out.tasks?.[0]?.agent, "general-executor");
+  assert.equal(out.__experts?.stageForced, true);
+  assert.equal(out.__experts?.stage, "execute");
+});
+
+test("P4 ensureExpertsDispatch params.stage works without opts.stage", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const out = ensureExpertsDispatch(
+    { tasks: [{ prompt: "随便" }], stage: "review" } as TeammateParamsLike,
+    { cwd, mode: "experts", record: false },
+  );
+  assert.equal(out.tasks?.[0]?.taskType, "review");
+  assert.equal(out.tasks?.[0]?.agent, "analyst");
+});
+
+test("P4 explicit taskType still wins over stage", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const out = ensureExpertsDispatch(
+    { tasks: [{ prompt: "x", taskType: "testing", agent: "general" }] },
+    { cwd, mode: "experts", record: false, stage: "execute" },
+  );
+  assert.equal(out.tasks?.[0]?.taskType, "testing");
+  assert.equal(out.tasks?.[0]?.agent, "general");
+  assert.equal(out.__experts?.stageForced, false);
+});
+
+test("P4 primaryStageAssignment and reminder mention stage", () => {
+  clearRulesCache();
+  const a = primaryStageAssignment("plan");
+  assert.equal(a?.taskType, "planning");
+  assert.equal(a?.agent, "planner");
+  const r = buildTurnReminder("experts", { stage: "execute" });
+  assert.ok(r.includes("execute"));
+  assert.ok(r.includes("stagePolicies") || r.includes("stage="));
+});
+
+test("P4 resolveStageExpertsPlan never sets model", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const plan = resolveStageExpertsPlan("debug", "修 bug", { cwd, mode: "experts", record: false });
+  assert.equal(plan.tasks[0]?.taskType, "debug");
+  assert.equal(plan.tasks[0]?.model, undefined);
+});
+
+// --- P5 Lead discipline ---
+import {
+  buildRewriteSuggestion,
+  matchPathPattern,
+  isHeavyMutationTool,
+} from "../src/experts-mode/index.ts";
+
+test("P5 denies business write with rewrite suggestion", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const gate = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    stage: "execute",
+    toolInput: { path: "packages/foo/src/index.ts", content: "x" },
+  });
+  assert.equal(gate.decision, "deny");
+  assert.ok(gate.reason.includes("DENIES") || gate.reason.includes("denies") || gate.reason.includes("teammate"));
+  assert.equal(gate.rewriteSuggestion?.action, "teammate");
+  assert.equal(gate.rewriteSuggestion?.taskType, "development");
+  assert.equal(gate.rewriteSuggestion?.agent, "general-executor");
+  assert.equal(gate.rewriteSuggestion?.stage, "execute");
+  assert.ok(String(gate.rewriteSuggestion?.pathHint || "").includes("index.ts"));
+});
+
+test("P5 allows leader write to report.md and outputs/**", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  assert.equal(
+    evaluateHardGate("write", {
+      cwd,
+      mode: "experts",
+      toolInput: { path: "report.md" },
+    }).decision,
+    "allow",
+  );
+  assert.equal(
+    evaluateHardGate("write", {
+      cwd,
+      mode: "experts",
+      toolInput: { path: "outputs/execution.json" },
+    }).decision,
+    "allow",
+  );
+  assert.equal(
+    evaluateHardGate("edit", {
+      cwd,
+      mode: "experts",
+      toolInput: { path: ".workflow/sessions/x/run.json" },
+    }).decision,
+    "allow",
+  );
+  assert.equal(
+    evaluateHardGate("write", {
+      cwd,
+      mode: "experts",
+      toolInput: { path: "notes/scratch.md" },
+    }).decision,
+    "allow",
+  );
+});
+
+test("P5 bash: deny destructive, allow maestro/git status", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const denied = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    stage: "execute",
+    toolInput: { command: "rm -rf src" },
+  });
+  assert.equal(denied.decision, "deny");
+  assert.ok(denied.rewriteSuggestion?.taskType);
+
+  assert.equal(
+    evaluateHardGate("bash", {
+      cwd,
+      mode: "experts",
+      toolInput: { command: "maestro session status foo" },
+    }).decision,
+    "allow",
+  );
+  assert.equal(
+    evaluateHardGate("bash", {
+      cwd,
+      mode: "experts",
+      toolInput: { command: "git status" },
+    }).decision,
+    "allow",
+  );
+});
+
+test("P5 stage influences rewrite taskType (review vs execute)", () => {
+  clearRulesCache();
+  const exec = buildRewriteSuggestion("write", { path: "src/a.ts" }, "execute");
+  assert.equal(exec.taskType, "development");
+  const rev = buildRewriteSuggestion("write", { path: "src/a.ts" }, "review");
+  assert.equal(rev.taskType, "review");
+  const ana = buildRewriteSuggestion("edit", { path: "src/a.ts" }, "analyze");
+  assert.equal(ana.taskType, "explore");
+});
+
+test("P5 matchPathPattern globs", () => {
+  const cwd = tempCwd();
+  assert.equal(matchPathPattern("outputs/a.json", "outputs/**", cwd), true);
+  assert.equal(matchPathPattern("src/a.ts", "outputs/**", cwd), false);
+  assert.equal(matchPathPattern("report.md", "report.md", cwd), true);
+  assert.equal(matchPathPattern("runs/x/report.md", "**/report.md", cwd), true);
+  assert.equal(isHeavyMutationTool("write"), true);
+  assert.equal(isHeavyMutationTool("read"), false);
+});
+
+test("P5 normal mode never denies", () => {
+  const cwd = tempCwd();
+  setMode("normal", cwd);
+  clearRulesCache();
+  assert.equal(
+    evaluateHardGate("write", {
+      cwd,
+      mode: "normal",
+      toolInput: { path: "src/secret.ts" },
+    }).decision,
+    "allow",
+  );
+});
+
+// --- P6 roster + observability ---
+import {
+  getRoster,
+  resolveRosterEntry,
+  agentForTaskTypeFromRoster,
+  buildCanvasSnapshot,
+  getInFlight,
+  trackInFlight,
+  settleInFlight,
+  clearInFlight,
+} from "../src/experts-mode/index.ts";
+
+test("P6 getRoster returns default roles without models", () => {
+  clearRulesCache();
+  const roster = getRoster();
+  assert.ok(roster.length >= 4);
+  const exec = roster.find((r) => r.id === "general-executor" || r.defaultTaskType === "development");
+  assert.ok(exec);
+  assert.equal(exec!.agent, "general-executor");
+  assert.equal(exec!.defaultTaskType, "development");
+  for (const r of roster) {
+    assert.ok(r.agent);
+    assert.ok(r.defaultTaskType);
+    assert.equal((r as { model?: string }).model, undefined);
+  }
+});
+
+test("P6 resolveRosterEntry by id/agent/taskType", () => {
+  clearRulesCache();
+  assert.equal(resolveRosterEntry("explorer")?.agent, "explorer");
+  assert.equal(resolveRosterEntry("development")?.agent, "general-executor");
+  assert.equal(resolveRosterEntry("planner")?.defaultTaskType, "planning");
+  assert.equal(agentForTaskTypeFromRoster("review"), "reviewer");
+});
+
+test("P6 getStatus includes roster, inFlight, activeStage", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearInFlight(cwd);
+  ensureExpertsDispatch(
+    { tasks: [{ name: "dev-1", prompt: "实现 x" }], stage: "execute" },
+    { cwd, mode: "experts", record: true },
+  );
+  const status = getStatus(cwd);
+  assert.equal(status.mode, "experts");
+  assert.ok(Array.isArray(status.roster) && status.roster.length > 0);
+  assert.ok(status.inFlight.some((e) => e.name === "dev-1" || e.id === "dev-1"));
+  assert.equal(status.activeStage?.stage, "execute");
+  assert.equal(status.leaderWaiting, true);
+});
+
+test("P6 settle clears inFlight with noteExpertsSettled", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearInFlight(cwd);
+  ensureExpertsDispatch(
+    { tasks: [{ name: "r1", agent: "general-executor", prompt: "x" }], stage: "execute" },
+    { cwd, mode: "experts", record: true },
+  );
+  assert.ok(getInFlight(cwd).length >= 1);
+  noteExpertsSettled(cwd, { agentId: "r1", settledCount: 1 });
+  const left = getInFlight(cwd);
+  assert.equal(left.find((e) => e.id === "r1" || e.name === "r1"), undefined);
+});
+
+test("P6 buildCanvasSnapshot schema", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  trackInFlight([{ id: "c1", agent: "analyst", taskType: "analysis", correlationId: "corr-1" }], { cwd, stage: "review" });
+  const snap = buildCanvasSnapshot(cwd);
+  assert.equal(snap.schema, "experts-canvas/1.0");
+  assert.equal(snap.mode, "experts");
+  assert.ok(snap.roster.length > 0);
+  assert.ok(snap.inFlight.some((e) => e.correlationId === "corr-1"));
+  assert.equal(typeof snap.updatedAt, "string");
+});
+
+test("P6 track/settle/clear inFlight helpers", () => {
+  const cwd = tempCwd();
+  clearInFlight(cwd);
+  trackInFlight([
+    { id: "a", agent: "explorer", taskType: "explore" },
+    { id: "b", agent: "analyst", taskType: "analysis", correlationId: "cid-b" },
+  ], { cwd });
+  assert.equal(getInFlight(cwd).length, 2);
+  settleInFlight("cid-b", { cwd });
+  assert.equal(getInFlight(cwd).length, 1);
+  settleInFlight("a", { cwd });
+  assert.equal(getInFlight(cwd).length, 0);
+});
+
+// --- P7 settle → knowledge harvest ---
+import {
+  harvestKnowledgeOnSettle,
+  assessKnowledgeCandidate,
+  getKnowledgeSuggestions,
+  clearKnowledgeSuggestions,
+  buildStageCommand,
+} from "../src/experts-mode/index.ts";
+
+const GOOD_PITFALL = [
+  "PITFALL: When doing experts hard-gate path matching on Windows,",
+  "normalize separators before glob match because mixed slash styles",
+  "silently miss allowlist entries and over-deny orchestration writes.",
+].join(" ");
+
+const RAW_TRACE = [
+  "tool_call write path=src/x.ts",
+  "Observation: wrote 12 bytes",
+  "teammate-complete correlationId=abc",
+].join("\n");
+
+test("P7 assess rejects raw traces and trivial text", () => {
+  assert.equal(assessKnowledgeCandidate("ok").ok, false);
+  assert.equal(assessKnowledgeCandidate(RAW_TRACE).ok, false);
+  assert.equal(assessKnowledgeCandidate(GOOD_PITFALL).ok, true);
+  assert.equal(assessKnowledgeCandidate(GOOD_PITFALL).kind, "pitfall");
+});
+
+test("P7 harvest extracts PITFALL and builds stage command", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearKnowledgeSuggestions(cwd);
+  const body = [
+    "Agent general-executor has completed.",
+    "--- RESULT ---",
+    GOOD_PITFALL,
+    "",
+    "Also: const x = 1; function foo(){ return x; }",
+  ].join("\n");
+  const result = harvestKnowledgeOnSettle(
+    {
+      content: body,
+      agentId: "general-executor",
+      taskType: "development",
+      stage: "execute",
+      sessionId: "sess-p7",
+      runId: "run-p7",
+    },
+    { cwd, record: true },
+  );
+  assert.ok(result.suggestions.length >= 1);
+  assert.equal(result.suggestions[0]?.target, "knowhow");
+  assert.ok(result.suggestions[0]?.content.includes("hard-gate") || result.suggestions[0]?.kind === "pitfall");
+  assert.ok(result.stageCommands[0]?.shell.includes("maestro knowledge stage"));
+  assert.ok(!result.stageCommands[0]?.shell.includes("promote"));
+  const stored = getKnowledgeSuggestions(cwd);
+  assert.ok(stored.length >= 1);
+  const status = getStatus(cwd);
+  assert.ok(status.knowledgeSuggestions.length >= 1);
+});
+
+test("P7 harvest dedups by fingerprint", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearKnowledgeSuggestions(cwd);
+  const input = { content: GOOD_PITFALL, agentId: "a", force: true as const };
+  const a = harvestKnowledgeOnSettle(input, { cwd, record: true });
+  const b = harvestKnowledgeOnSettle(input, { cwd, record: true });
+  assert.ok(a.suggestions.length >= 1);
+  assert.equal(b.suggestions.length, 0);
+  assert.ok(b.skipped.some((s) => /duplicate/i.test(s.reason)));
+});
+
+test("P7 noteExpertsSettled harvests when content provided", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearKnowledgeSuggestions(cwd);
+  setLeaderWaiting(true, { cwd, activeDelta: 1, agentIds: ["dev"] });
+  const out = noteExpertsSettled(cwd, {
+    settledCount: 1,
+    agentId: "dev",
+    content: GOOD_PITFALL,
+    taskType: "development",
+    stage: "execute",
+  });
+  assert.equal(out.leaderWaiting, false);
+  assert.ok(out.knowledgeHarvest);
+  assert.ok((out.knowledgeHarvest?.suggestions.length ?? 0) >= 1);
+});
+
+test("P7 rejects code-only dump without lesson", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const code = "function f(a,b){return a+b;} const o={x:1,y:2,z:3}; export default f;";
+  const r = harvestKnowledgeOnSettle({ content: code.repeat(3), force: true }, { cwd, record: false });
+  assert.equal(r.suggestions.length, 0);
+});
+
+test("P7 buildStageCommand never promotes", () => {
+  const cmd = buildStageCommand({
+    id: "kh-1",
+    target: "knowhow",
+    kind: "pitfall",
+    title: "path normalize",
+    content: GOOD_PITFALL,
+    fingerprint: "abc",
+    score: 5,
+    evidence: [],
+    at: new Date().toISOString(),
+    source: "experts-settle",
+    sessionId: "s1",
+  });
+  assert.ok(cmd.shell.includes("knowledge stage"));
+  assert.equal(cmd.shell.includes("promote"), false);
+});
+
+// --- P7b cockpit status + autoStage self-evolve pool ---
+import {
+  formatExpertsHarvestStatus,
+  EXPERTS_HARVEST_STATUS_KEY,
+  depositHarvestToSelfEvolvePool,
+  harvestToSelfEvolveSignal,
+  dailySuggestionFileName,
+} from "../src/experts-mode/index.ts";
+import { loadRules as loadExpertsRules } from "../src/experts-mode/rules.ts";
+
+test("P7b formatExpertsHarvestStatus", () => {
+  assert.equal(formatExpertsHarvestStatus([]), "");
+  assert.equal(formatExpertsHarvestStatus(3), "HARVEST 3");
+  assert.equal(EXPERTS_HARVEST_STATUS_KEY, "experts-harvest");
+  const sample = [{
+    id: "kh-1",
+    target: "knowhow" as const,
+    kind: "pitfall" as const,
+    title: "t",
+    content: "c",
+    fingerprint: "f",
+    score: 3,
+    evidence: [],
+    at: new Date().toISOString(),
+    source: "experts-settle" as const,
+  }];
+  const text = formatExpertsHarvestStatus(sample);
+  assert.ok(text.startsWith("HARVEST 1"));
+  assert.ok(text.includes("pitfall"));
+});
+
+test("P7b depositHarvestToSelfEvolvePool writes se- signal + evidence", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "se-pool-"));
+  const suggestion = {
+    id: "kh-abc",
+    target: "knowhow" as const,
+    kind: "pitfall" as const,
+    title: "path normalize on windows",
+    content: GOOD_PITFALL,
+    fingerprint: "deadbeefcafef00ddeadbeefcafef00ddeadbeefcafef00ddeadbeefcafef00d",
+    score: 5,
+    evidence: ["notes/x.md"],
+    at: new Date().toISOString(),
+    source: "experts-settle" as const,
+    sessionId: "sess-1",
+    runId: "run-1",
+    agentId: "general-executor",
+  };
+  const r = depositHarvestToSelfEvolvePool([suggestion], {
+    outputRoot: root,
+    sessionId: "sess-1",
+    runId: "run-1",
+    project: "expert",
+  });
+  assert.equal(r.written, 1);
+  assert.ok(r.filePath);
+  assert.ok(fs.existsSync(r.filePath!));
+  const line = fs.readFileSync(r.filePath!, "utf8").trim();
+  const row = JSON.parse(line);
+  assert.ok(String(row.id).startsWith("se-"));
+  assert.equal(row.kind, "candidate");
+  assert.equal(row.dryRun, true);
+  assert.equal(row.skill, "experts-harvest");
+  assert.ok(row.suggestion.includes("knowledge stage"));
+  assert.equal(row.suggestion.includes("promote"), false);
+  const evidenceFile = path.join(root, "evidence", `${row.id}.md`);
+  assert.ok(fs.existsSync(evidenceFile));
+  // dedupe second write
+  const r2 = depositHarvestToSelfEvolvePool([suggestion], { outputRoot: root });
+  assert.equal(r2.written, 0);
+  assert.equal(r2.skipped, 1);
+});
+
+test("P7b autoStage deposits when rules.settle.autoStage true", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearKnowledgeSuggestions(cwd);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "se-auto-"));
+  const rules = {
+    ...loadExpertsRules(),
+    settle: {
+      knowledgeHarvest: true,
+      autoStage: true,
+      selfEvolveOutputRoot: root,
+      maxSuggestions: 5,
+    },
+  };
+  const result = harvestKnowledgeOnSettle(
+    {
+      content: GOOD_PITFALL,
+      agentId: "dev",
+      sessionId: "s-auto",
+      runId: "r-auto",
+      force: true,
+    },
+    { cwd, record: true, rules },
+  );
+  assert.ok(result.suggestions.length >= 1);
+  assert.ok(result.poolDeposit);
+  assert.equal(result.poolDeposit?.written, 1);
+  assert.ok(result.poolDeposit?.filePath && fs.existsSync(result.poolDeposit.filePath));
+});
+
+// --- P4.1 Maestro stage auto-injection ---
+import {
+  resolveMaestroStageFromWorkspace,
+  syncActiveStageFromMaestro,
+  formatStageBirthPacket,
+} from "../src/experts-mode/index.ts";
+
+/** Write a fake Maestro session.json under cwd/.workflow/sessions/<id>/. */
+function writeSessionFixture(
+  cwd: string,
+  sessionId: string,
+  opts: {
+    intent?: string;
+    status?: string;
+    activeRunId?: string | null;
+    chain?: Array<Record<string, unknown>>;
+    sealed?: boolean;
+  } = {},
+): string {
+  const dir = path.join(cwd, ".workflow", "sessions", sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const chain = opts.chain ?? [
+    { step_id: "step-1", command: "execute", status: "running", run_id: "run-1", stage: "execute" },
+  ];
+  const session: Record<string, unknown> = {
+    session_id: sessionId,
+    intent: opts.intent ?? "P4.1 test intent",
+    status: opts.status ?? (opts.sealed ? "sealed" : "running"),
+    active_run_id: opts.activeRunId === null ? undefined : (opts.activeRunId ?? "run-1"),
+    orchestration: { chain },
+    lifecycle: opts.sealed ? { sealed_at: "2026-08-10T00:00:00.000Z" } : { sealed_at: null },
+  };
+  fs.writeFileSync(path.join(dir, "session.json"), `${JSON.stringify(session, null, 2)}\n`, "utf8");
+  return dir;
+}
+
+/** Run fn with MAESTRO_SESSION_ID / MAESTRO_STAGE unset, restoring afterwards. */
+function withCleanMaestroEnv<T>(fn: () => T): T {
+  const prevId = process.env.MAESTRO_SESSION_ID;
+  const prevStage = process.env.MAESTRO_STAGE;
+  delete process.env.MAESTRO_SESSION_ID;
+  delete process.env.MAESTRO_STAGE;
+  try {
+    return fn();
+  } finally {
+    if (prevId === undefined) delete process.env.MAESTRO_SESSION_ID;
+    else process.env.MAESTRO_SESSION_ID = prevId;
+    if (prevStage === undefined) delete process.env.MAESTRO_STAGE;
+    else process.env.MAESTRO_STAGE = prevStage;
+  }
+}
+
+test("P4.1 resolveMaestroStageFromWorkspace finds running session stage=execute", () => {
+  const cwd = tempCwd();
+  writeSessionFixture(cwd, "sess-run-1", { intent: "实现 JWT 中间件" });
+  withCleanMaestroEnv(() => {
+    const info = resolveMaestroStageFromWorkspace(cwd);
+    assert.ok(info);
+    assert.equal(info!.sessionId, "sess-run-1");
+    assert.equal(info!.stage, "execute");
+    assert.equal(info!.command, "execute");
+    assert.equal(info!.runId, "run-1");
+    assert.equal(info!.stepId, "step-1");
+    assert.equal(info!.intent, "实现 JWT 中间件");
+    assert.equal(info!.source, "workspace");
+  });
+});
+
+test("P4.1 stage falls back to step.command and alias mapping", () => {
+  const cwd = tempCwd();
+  writeSessionFixture(cwd, "sess-cmd", {
+    chain: [{ step_id: "s1", command: "maestro-execute", status: "running", run_id: "r1" }],
+  });
+  withCleanMaestroEnv(() => {
+    const info = resolveMaestroStageFromWorkspace(cwd);
+    assert.ok(info);
+    assert.equal(info!.stage, "execute"); // alias maestro-execute → execute
+  });
+});
+
+test("P4.1 MAESTRO_SESSION_ID env wins over workspace scan", () => {
+  const cwd = tempCwd();
+  writeSessionFixture(cwd, "env-sess", {
+    intent: "env intent",
+    activeRunId: "r-env",
+    chain: [{ step_id: "s1", command: "review", status: "running", run_id: "r-env", stage: "review" }],
+  });
+  // decoy running session — env must beat the scan
+  writeSessionFixture(cwd, "decoy-run", { intent: "decoy", activeRunId: "r-decoy" });
+  const prevId = process.env.MAESTRO_SESSION_ID;
+  const prevStage = process.env.MAESTRO_STAGE;
+  process.env.MAESTRO_SESSION_ID = "env-sess";
+  delete process.env.MAESTRO_STAGE;
+  try {
+    const info = resolveMaestroStageFromWorkspace(cwd);
+    assert.ok(info);
+    assert.equal(info!.source, "env");
+    assert.equal(info!.sessionId, "env-sess");
+    assert.equal(info!.stage, "review");
+  } finally {
+    if (prevId === undefined) delete process.env.MAESTRO_SESSION_ID;
+    else process.env.MAESTRO_SESSION_ID = prevId;
+    if (prevStage === undefined) delete process.env.MAESTRO_STAGE;
+    else process.env.MAESTRO_STAGE = prevStage;
+  }
+});
+
+test("P4.1 ensureExpertsDispatch auto-detects stage from workspace", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  writeSessionFixture(cwd, "sess-exec");
+  withCleanMaestroEnv(() => {
+    // Prompt looks like explore; stage=execute from session.json must force development.
+    const out = ensureExpertsDispatch(
+      { tasks: [{ prompt: "搜索 PositionManager 调用链" }] } as TeammateParamsLike,
+      { cwd, mode: "experts", record: false },
+    );
+    assert.equal(out.tasks?.[0]?.taskType, "development");
+    assert.equal(out.tasks?.[0]?.agent, "general-executor");
+    assert.equal(out.__experts?.stageForced, true);
+    assert.equal(out.__experts?.stage, "execute");
+  });
+});
+
+test("P4.1 syncActiveStageFromMaestro writes activeStage", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  writeSessionFixture(cwd, "sess-sync", { intent: "实现 JWT 中间件" });
+  withCleanMaestroEnv(() => {
+    const plan = syncActiveStageFromMaestro(cwd);
+    assert.ok(plan);
+    assert.equal(plan!.mode, "experts");
+    assert.equal(plan!.stage, "execute");
+    assert.equal(plan!.source, "stage-policy");
+    assert.ok(plan!.tasks.length >= 1);
+    assert.equal(plan!.tasks[0]?.taskType, "development");
+    const status = getStatus(cwd);
+    assert.equal(status.activeStage?.stage, "execute");
+    assert.equal(status.activeStage?.source, "maestro-session");
+    assert.equal(status.activeStage?.sessionId, "sess-sync");
+    assert.equal(status.activeStage?.runId, "run-1");
+    assert.ok((status.activeStage?.taskTypes ?? []).includes("development"));
+    // env backfill: MAESTRO_STAGE set once when unset
+    assert.equal(process.env.MAESTRO_STAGE, "execute");
+    // second sync does not clobber an explicit env stage
+    process.env.MAESTRO_STAGE = "review";
+    const again = syncActiveStageFromMaestro(cwd);
+    assert.ok(again);
+    assert.equal(process.env.MAESTRO_STAGE, "review");
+  });
+});
+
+test("P4.1 formatStageBirthPacket is a short leader-facing fragment", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const plan = resolveStageExpertsPlan("execute", "实现 JWT", { cwd, mode: "experts", record: false });
+  const packet = formatStageBirthPacket(plan);
+  assert.match(packet, /Stage birth: "execute"/);
+  assert.match(packet, /Pipeline: development/);
+  assert.match(packet, /Agents: general-executor/);
+  assert.ok(packet.split("\n").length <= 6);
+});
+
+test("P4.1 missing sessions → null / no throw", () => {
+  const cwd = tempCwd();
+  withCleanMaestroEnv(() => {
+    // no .workflow at all
+    assert.equal(resolveMaestroStageFromWorkspace(cwd), null);
+    // .workflow/sessions exists but is empty
+    fs.mkdirSync(path.join(cwd, ".workflow", "sessions"), { recursive: true });
+    assert.equal(resolveMaestroStageFromWorkspace(cwd), null);
+    // broken json session file is skipped, no throw
+    writeSessionFixture(cwd, "bad");
+    fs.writeFileSync(
+      path.join(cwd, ".workflow", "sessions", "bad", "session.json"),
+      "not json {{",
+      "utf8",
+    );
+    assert.equal(resolveMaestroStageFromWorkspace(cwd), null);
+    // sealed sessions are ignored (no active step)
+    writeSessionFixture(cwd, "sealed-1", { sealed: true });
+    assert.equal(resolveMaestroStageFromWorkspace(cwd), null);
+    // sync in normal mode: found session → normal plan, no state written
+    writeSessionFixture(cwd, "normal-1");
+    const plan = syncActiveStageFromMaestro(cwd, { mode: "normal" });
+    assert.ok(plan);
+    assert.equal(plan!.mode, "normal");
+    assert.equal(getStatus(cwd).activeStage, null);
+  });
+});
+
+// --- P5.1 Orchestrator discipline ---
+import {
+  ORCHESTRATOR_DISCIPLINE_MARK,
+  buildOrchestratorDisciplineFragment,
+  buildViceLeadDispatchHint,
+  shouldSuggestViceLead,
+  mergeRules,
+} from "../src/experts-mode/index.ts";
+
+test("P5.1 discipline fragment mentions session/run and dispatch", () => {
+  const f = buildOrchestratorDisciplineFragment();
+  assert.match(f, /session\/run/);
+  assert.match(f, /dispatch/);
+  assert.match(f, /NEVER implement business code/);
+  assert.match(f, /outputs\/\*\*/);
+  assert.ok(f.includes(ORCHESTRATOR_DISCIPLINE_MARK));
+  // no vice-lead guidance for a single-task pipeline
+  assert.ok(!f.includes("vice-lead"));
+  assert.ok(f.split("\n").length < 12);
+});
+
+test("P5.1 viceLead lines appear when taskTypes length >= 2", () => {
+  const f = buildOrchestratorDisciplineFragment({
+    taskTypes: ["explore", "planning", "development", "review"],
+  });
+  assert.match(f, /vice-lead/);
+  assert.match(f, /agent=workflow/);
+  assert.match(f, /taskType=planning/);
+  assert.ok(shouldSuggestViceLead({ taskTypes: ["explore", "planning"] }));
+  assert.ok(shouldSuggestViceLead({ agents: ["a", "b"] }));
+  assert.ok(!shouldSuggestViceLead({ taskTypes: ["development"] }));
+  assert.ok(!shouldSuggestViceLead({}));
+  // force includes vice-lead even for single-step
+  assert.ok(shouldSuggestViceLead({ taskTypes: ["development"], force: true }));
+});
+
+test("P5.1 viceLead suppressed when rules.orchestrator.viceLead=false", () => {
+  const rules = { orchestrator: { viceLead: false } };
+  const f = buildOrchestratorDisciplineFragment({
+    taskTypes: ["explore", "planning", "development", "review"],
+    rules,
+  });
+  assert.ok(!f.includes("vice-lead"));
+  assert.equal(shouldSuggestViceLead({ taskTypes: ["a", "b"], rules }), false);
+  // rules-level off cannot be overridden by force
+  assert.equal(shouldSuggestViceLead({ taskTypes: ["a", "b"], rules, force: true }), false);
+  // explicit opts.viceLead=false also suppresses
+  const g = buildOrchestratorDisciplineFragment({
+    taskTypes: ["a", "b"],
+    viceLead: false,
+  });
+  assert.ok(!g.includes("vice-lead"));
+});
+
+test("P5.1 buildTurnReminder includes orchestrator discipline markers when experts", () => {
+  const r = buildTurnReminder("experts", {
+    stage: "execute",
+    taskTypes: ["development"],
+  });
+  assert.match(r, /Orchestrator discipline \(P5\.1\)/);
+  assert.match(r, /session\/run/);
+  assert.match(r, /dispatch/);
+  assert.ok(r.indexOf("Orchestrator discipline") > r.indexOf("<experts_mode_reminder>"));
+  assert.ok(r.indexOf("Orchestrator discipline") < r.indexOf("</experts_mode_reminder>"));
+  // normal mode stays empty
+  assert.equal(buildTurnReminder("normal", { stage: "execute" }), "");
+  // injectTurnReminder passthrough
+  const injected = injectTurnReminder("BASE", {
+    mode: "experts",
+    stage: "execute",
+    taskTypes: ["development"],
+  });
+  assert.match(injected, /Orchestrator discipline/);
+  assert.match(injected, /BASE/);
+});
+
+test("P5.1 disciplineReminder=false omits discipline fragment", () => {
+  const r = buildTurnReminder("experts", {
+    rules: { orchestrator: { disciplineReminder: false } },
+  });
+  assert.ok(!r.includes("Orchestrator discipline"));
+  assert.ok(r.includes("experts_mode_reminder"));
+  // explicit opts.discipline=false also suppresses
+  const r2 = buildTurnReminder("experts", { discipline: false });
+  assert.ok(!r2.includes("Orchestrator discipline"));
+  assert.ok(r2.includes("experts_mode_reminder"));
+});
+
+test("P5.1 vice-lead dispatch hint is role-based, never a model", () => {
+  const hint = buildViceLeadDispatchHint("execute", "multi-step feature");
+  assert.equal(hint.agent, "workflow");
+  assert.equal(hint.taskType, "planning");
+  assert.equal(hint.model, undefined);
+  assert.ok(String(hint.prompt).includes("vice-lead"));
+  assert.ok(!String(hint.agent).includes("/"));
+});
+
+test("P5.1 mergeRules merges orchestrator shallowly", () => {
+  const merged = mergeRules(
+    { orchestrator: { disciplineReminder: true, viceLead: true } },
+    { orchestrator: { viceLead: false } },
+  );
+  assert.equal(merged.orchestrator?.disciplineReminder, true);
+  assert.equal(merged.orchestrator?.viceLead, false);
+  // absent overlay keeps base
+  const kept = mergeRules(
+    { orchestrator: { disciplineReminder: true, viceLead: true } },
+    {},
+  );
+  assert.equal(kept.orchestrator?.viceLead, true);
+});

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -1235,3 +1235,102 @@ test("A2 LastDispatch shows taskType/stage without a model line", () => {
   assert.match(panel, /name=dev-1/);
   assert.match(panel, /taskType=development/);
 });
+
+// --- A3 /experts CLI panel views (roster|waiting|harvest) ---
+import {
+  formatExpertsPanel,
+  formatExpertsPanelFromStatus,
+  formatExpertsRosterPanelFromStatus,
+  formatExpertsWaitingPanelFromStatus,
+  formatExpertsHarvestPanelFromStatus,
+} from "../src/experts-mode/index.ts";
+
+test("A3 roster panel lists enabled-first roles with agent and taskType", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const panel = formatExpertsRosterPanelFromStatus(getStatus(cwd));
+  assert.match(panel, /Roster/);
+  assert.match(panel, /general-executor/);
+  assert.match(panel, /\| general-executor \| development \|/);
+  assert.match(panel, /role ≠ model/);
+  assert.ok(!panel.includes("model="), "rows must not carry model ids");
+});
+
+test("A3 roster panel orders enabled before disabled and shows empty fallback", () => {
+  const status = getStatus(tempCwd());
+  const mixed = formatExpertsRosterPanelFromStatus({
+    ...status,
+    roster: [
+      { id: "z-role", agent: "z-agent", defaultTaskType: "review", enabled: false },
+      { id: "a-role", agent: "a-agent", defaultTaskType: "development", enabled: true },
+    ],
+  });
+  const lines = mixed.split("\n");
+  const enabledIdx = lines.findIndex((l) => l.startsWith("a-role"));
+  const disabledIdx = lines.findIndex((l) => l.startsWith("z-role"));
+  assert.ok(enabledIdx > 0 && disabledIdx > enabledIdx, "enabled entries render first");
+  assert.match(mixed, /disabled/);
+  const empty = formatExpertsRosterPanelFromStatus({ ...status, roster: [] });
+  assert.match(empty, /\(no roster — using taskType defaults\)/);
+});
+
+test("A3 waiting panel shows waiting yes with agent ids and in-flight", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearInFlight(cwd);
+  setLeaderWaiting(true, { cwd, activeDelta: 2, agentIds: ["general-executor", "explorer"] });
+  trackInFlight([
+    { id: "dev-1", name: "dev-1", agent: "general-executor", taskType: "development" },
+  ], { cwd });
+  const panel = formatExpertsWaitingPanelFromStatus(getStatus(cwd));
+  assert.match(panel, /LeaderWaiting: yes \(2\)/);
+  assert.match(panel, /agents=\[general-executor, explorer\]/);
+  assert.match(panel, /InFlight: 1/);
+  assert.match(panel, /name=dev-1/);
+  assert.match(panel, /taskType=development/);
+  assert.match(panel, /do not claim done while waiting/);
+  assert.ok(!panel.includes("model"), "waiting panel must not leak model ids");
+});
+
+test("A3 harvest panel empty shows none", () => {
+  const cwd = tempCwd();
+  clearKnowledgeSuggestions(cwd);
+  const panel = formatExpertsHarvestPanelFromStatus(getStatus(cwd));
+  assert.match(panel, /\(none — settle harvest is suggest-only\)/);
+  assert.match(panel, /Never auto-promote/);
+});
+
+test("A3 harvest panel lists pending suggestions with id/kind/score", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  clearKnowledgeSuggestions(cwd);
+  const result = harvestKnowledgeOnSettle(
+    { content: GOOD_PITFALL, agentId: "dev", taskType: "development", force: true },
+    { cwd, record: true },
+  );
+  assert.ok(result.suggestions.length >= 1);
+  const panel = formatExpertsHarvestPanelFromStatus(getStatus(cwd));
+  assert.match(panel, /Summary: HARVEST 1/);
+  assert.match(panel, /pitfall/);
+  assert.match(panel, /score=\d/);
+  assert.match(panel, /Never auto-promote/);
+});
+
+test("A3 formatExpertsPanelFromStatus switches views and formatExpertsPanel defaults", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearRulesCache();
+  const status = getStatus(cwd);
+  assert.match(formatExpertsPanelFromStatus(status, "status"), /Experts Mode Status/);
+  assert.match(formatExpertsPanelFromStatus(status, "roster"), /Experts Roster/);
+  assert.match(formatExpertsPanelFromStatus(status, "waiting"), /Experts Waiting/);
+  assert.match(formatExpertsPanelFromStatus(status, "harvest"), /Experts Harvest/);
+  assert.match(formatExpertsPanelFromStatus(status), /Experts Mode Status/);
+  assert.match(formatExpertsPanel(cwd), /Experts Mode Status/);
+  assert.match(formatExpertsPanel(cwd, "roster"), /Experts Roster/);
+  assert.match(formatExpertsPanel(cwd, "waiting"), /Experts Waiting/);
+  assert.match(formatExpertsPanel(cwd, "harvest"), /Experts Harvest/);
+});

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -27,8 +27,12 @@ import {
   clearRulesCache,
   EXPERTS_SKILLS_START,
   getRoster,
+  hasDangerousShellMetachar,
+  mergeRules,
+  mergeRosterMaps,
   type TeammateParamsLike,
 } from "../src/experts-mode/index.ts";
+
 
 function tempCwd(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "experts-mode-wire-"));
@@ -1071,7 +1075,6 @@ import {
   buildOrchestratorDisciplineFragment,
   buildViceLeadDispatchHint,
   shouldSuggestViceLead,
-  mergeRules,
 } from "../src/experts-mode/index.ts";
 
 test("P5.1 discipline fragment mentions session/run and dispatch", () => {
@@ -1483,5 +1486,166 @@ test("A5 planner dispatch injects maestro skill guidance", () => {
   } as TeammateParamsLike, { cwd, mode: "experts", record: false, rules });
   assert.match(String(out.tasks?.[0]?.prompt), /experts-skills:start/);
   assert.match(String(out.tasks?.[0]?.prompt), /maestro-next|maestro/);
+  clearRulesCache();
+});
+
+
+// --- A6 audit fixes H1/H2/M5/M1 ---
+
+test("A6 H2 hasDangerousShellMetachar detects chains", () => {
+  assert.equal(hasDangerousShellMetachar("git status"), false);
+  assert.equal(hasDangerousShellMetachar("cat foo && rm -rf src"), true);
+  assert.equal(hasDangerousShellMetachar("npm test; node -e x"), true);
+  assert.equal(hasDangerousShellMetachar("echo hi | tee log"), true);
+  assert.equal(hasDangerousShellMetachar("echo $(whoami)"), true);
+});
+
+test("A6 H2 bash chain denied under experts allowlist prefix", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const chain = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    toolInput: { command: "cat notes/a.md && rm -rf src" },
+  });
+  assert.equal(chain.decision, "deny");
+  const ok = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    toolInput: { command: "git status" },
+  });
+  assert.equal(ok.decision, "allow");
+  clearRulesCache();
+});
+
+test("A6 H1 evaluateHardGate uses project rules from cwd", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  fs.writeFileSync(
+    path.join(cwd, ".experts-rules.json"),
+    JSON.stringify({
+      hardGate: {
+        default: "allow",
+        tools: { write: "allow", edit: "allow", bash: "deny", bash_bg: "deny" },
+      },
+    }, null, 2),
+    "utf8",
+  );
+  // write to business path would be deny under package defaults; project sets write=allow
+  const gate = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    toolInput: { path: "src/business.ts" },
+  });
+  assert.equal(gate.decision, "allow", gate.reason);
+  clearRulesCache();
+});
+
+test("A6 M5 mergeRules deep-merges roster entries", () => {
+  const base = {
+    roster: {
+      explorer: {
+        agent: "explorer",
+        defaultTaskType: "explore",
+        capabilities: ["explore", "search"],
+        skills: [] as string[],
+      },
+    },
+  };
+  const overlay = {
+    roster: {
+      explorer: {
+        skills: ["smart-search-cli"],
+      },
+    },
+  };
+  const merged = mergeRules(base as any, overlay as any);
+  const ex = merged.roster?.explorer as any;
+  assert.equal(ex.agent, "explorer");
+  assert.equal(ex.defaultTaskType, "explore");
+  assert.deepEqual(ex.capabilities, ["explore", "search"]);
+  assert.deepEqual(ex.skills, ["smart-search-cli"]);
+  // mergeRosterMaps unit
+  const m = mergeRosterMaps(
+    { a: { agent: "x", skills: [] } },
+    { a: { skills: ["m"] } },
+  );
+  assert.equal((m.a as any).agent, "x");
+  assert.deepEqual((m.a as any).skills, ["m"]);
+});
+
+test("A6 M1 setLeaderWaiting / noteExpertsSettled keep non-negative count", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  setLeaderWaiting(true, { cwd, activeDelta: 2, agentIds: ["a", "b"] });
+  noteExpertsSettled(cwd, { settledCount: 1, reason: "t1" });
+  noteExpertsSettled(cwd, { settledCount: 1, reason: "t2" });
+  noteExpertsSettled(cwd, { settledCount: 3, reason: "over" });
+  const st = getLeaderWaiting(cwd);
+  assert.ok(st.activeCount >= 0);
+  assert.equal(st.activeCount, 0);
+  assert.equal(st.leaderWaiting, false);
+  clearRulesCache();
+});
+
+
+test("A6 CV-01 expert caller skips hard-gate", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const leader = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    toolInput: { path: "src/evil.ts" },
+  });
+  assert.equal(leader.decision, "deny");
+  const expert = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    caller: "expert",
+    toolInput: { path: "src/evil.ts" },
+  });
+  assert.equal(expert.decision, "allow");
+  clearRulesCache();
+});
+
+test("A6 HV-02 bash redirect and node -e denied", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const redir = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    toolInput: { command: "cat report.md > src/evil.ts" },
+  });
+  assert.equal(redir.decision, "deny");
+  const nodee = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    toolInput: { command: "node --test -e \"require('fs').writeFileSync('x','y')\"" },
+  });
+  assert.equal(nodee.decision, "deny");
+  const falsePrefix = evaluateHardGate("bash", {
+    cwd,
+    mode: "experts",
+    toolInput: { command: "npm testify" },
+  });
+  assert.equal(falsePrefix.decision, "deny");
+  clearRulesCache();
+});
+
+test("A6 HV-04 writing .experts-mode.json is not path-allowlisted", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const gate = evaluateHardGate("write", {
+    cwd,
+    mode: "experts",
+    toolInput: { path: ".experts-mode.json" },
+  });
+  assert.equal(gate.decision, "deny");
   clearRulesCache();
 });

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -1169,3 +1169,69 @@ test("P5.1 mergeRules merges orchestrator shallowly", () => {
   );
   assert.equal(kept.orchestrator?.viceLead, true);
 });
+
+// --- A2 experts status panel ---
+import {
+  formatExpertsStatusPanel,
+  formatExpertsStatusPanelFromStatus,
+  recordLastDispatch,
+} from "../src/experts-mode/index.ts";
+
+test("A2 status panel renders normal mode without throwing", () => {
+  const cwd = tempCwd();
+  const panel = formatExpertsStatusPanel(cwd);
+  assert.match(panel, /Mode: normal/);
+  assert.match(panel, /LeaderWaiting: no/);
+  assert.match(panel, /ActiveStage: \(none\)/);
+  assert.match(panel, /LastDispatch: \(none\)/);
+  assert.match(panel, /InFlight: 0/);
+  assert.match(panel, /Harvest: \(none\)/);
+  assert.ok(panel.includes(".experts-mode.json"), "panel must show the state path");
+  // pure formatter path from an already-built status object
+  const direct = formatExpertsStatusPanelFromStatus(getStatus(cwd));
+  assert.match(direct, /Mode: normal/);
+  assert.match(direct, /Path:/);
+});
+
+test("A2 status panel shows experts mode and leader waiting", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  setLeaderWaiting(true, { cwd, activeDelta: 2, agentIds: ["general-executor", "explorer"] });
+  const panel = formatExpertsStatusPanel(cwd);
+  assert.match(panel, /Mode: experts/);
+  assert.match(panel, /LeaderWaiting: yes \(2\)/);
+  assert.match(panel, /agents=\[general-executor, explorer\]/);
+  assert.ok(!panel.includes("model"), "panel must never contain model ids");
+});
+
+test("A2 LastDispatch shows taskType/stage without a model line", () => {
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  clearInFlight(cwd);
+  recordLastDispatch({
+    mode: "experts",
+    taskType: "development",
+    agent: "general-executor",
+    model: "sub2-responses/gpt-5.4", // routing-only — must never render
+    forced: true,
+    stage: "execute",
+    at: "2026-08-10T00:00:00.000Z",
+    promptPreview: `preview-${"x".repeat(100)}`, // longer than 80 → truncated
+  }, cwd);
+  trackInFlight([
+    { id: "dev-1", name: "dev-1", agent: "general-executor", taskType: "development" },
+  ], { cwd });
+  const panel = formatExpertsStatusPanel(cwd);
+  assert.match(panel, /LastDispatch:/);
+  assert.match(panel, /taskType=development/);
+  assert.match(panel, /agent=general-executor/);
+  assert.match(panel, /stage=execute/);
+  assert.match(panel, /forced=true/);
+  assert.match(panel, /at=2026-08-10T00:00:00\.000Z/);
+  assert.match(panel, /prompt="preview-/);
+  assert.ok(panel.includes("…"), "over-80 preview must be truncated");
+  assert.ok(!panel.includes("model"), "panel must never leak model ids");
+  assert.match(panel, /InFlight: 1/);
+  assert.match(panel, /name=dev-1/);
+  assert.match(panel, /taskType=development/);
+});

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -18,6 +18,14 @@ import {
   formatExpertResult,
   parseExpertResultAgentId,
   noteExpertsSettled,
+  resolveModelRef,
+  resolveChannel,
+  applyExpertProfiles,
+  resolveExpertProfile,
+  defaultRulesPath,
+  loadRules,
+  clearRulesCache,
+  EXPERTS_SKILLS_START,
   type TeammateParamsLike,
 } from "../src/experts-mode/index.ts";
 
@@ -311,7 +319,6 @@ import {
   resolveStageName,
   getStagePolicy,
   primaryStageAssignment,
-  clearRulesCache,
 } from "../src/experts-mode/index.ts";
 
 test("P4 resolveStageName aliases maestro-execute → execute", () => {
@@ -1333,4 +1340,119 @@ test("A3 formatExpertsPanelFromStatus switches views and formatExpertsPanel defa
   assert.match(formatExpertsPanel(cwd, "roster"), /Experts Roster/);
   assert.match(formatExpertsPanel(cwd, "waiting"), /Experts Waiting/);
   assert.match(formatExpertsPanel(cwd, "harvest"), /Experts Harvest/);
+});
+
+
+// ---------------------------------------------------------------------------
+// A4: expert profiles (model / channel / skills)
+// ---------------------------------------------------------------------------
+
+test("A4 resolveChannel uses aliases", () => {
+  const rules = { channels: { cpa: "cpa-responses", sub2: "sub2-responses" } };
+  assert.equal(resolveChannel("cpa", rules), "cpa-responses");
+  assert.equal(resolveChannel("sub2", rules), "sub2-responses");
+  assert.equal(resolveChannel("already-provider", rules), "already-provider");
+  assert.equal(resolveChannel(undefined, rules), undefined);
+});
+
+test("A4 resolveModelRef joins channel + bare model", () => {
+  const rules = { channels: { cpa: "cpa-responses" } };
+  assert.equal(resolveModelRef("deepseek-v4-flash", "cpa", rules), "cpa-responses/deepseek-v4-flash");
+  assert.equal(resolveModelRef("cpa-responses/grok-4.5", "cpa", rules), "cpa-responses/grok-4.5");
+  assert.equal(resolveModelRef("bare-only", undefined, rules), "bare-only");
+  assert.equal(resolveModelRef(undefined, "cpa", rules), undefined);
+});
+
+test("A4 applyExpertProfiles fills model under experts and no-ops normal", () => {
+  const rules = {
+    channels: { cpa: "cpa-responses" },
+    roster: {
+      explorer: {
+        agent: "explorer",
+        defaultTaskType: "explore",
+        channel: "cpa",
+        model: "deepseek-v4-flash",
+        skills: ["smart-search-cli"],
+      },
+    },
+  };
+  const base: TeammateParamsLike = {
+    tasks: [{ prompt: "search call chain", agent: "explorer", taskType: "explore" }],
+  };
+  const normal = applyExpertProfiles(base, { mode: "normal", rules: rules as any });
+  assert.equal(normal.tasks?.[0]?.model, undefined);
+
+  const experts = applyExpertProfiles(base, { mode: "experts", rules: rules as any });
+  assert.equal(experts.tasks?.[0]?.model, "cpa-responses/deepseek-v4-flash");
+  assert.match(String(experts.tasks?.[0]?.prompt), /experts-skills:start/);
+  assert.match(String(experts.tasks?.[0]?.prompt), /smart-search-cli/);
+});
+
+test("A4 applyExpertProfiles does not override explicit task.model", () => {
+  const rules = {
+    roster: {
+      explorer: {
+        agent: "explorer",
+        defaultTaskType: "explore",
+        model: "cpa-responses/deepseek-v4-flash",
+      },
+    },
+  };
+  const out = applyExpertProfiles({
+    tasks: [{
+      prompt: "x",
+      agent: "explorer",
+      taskType: "explore",
+      model: "sub2-responses/gpt-5.6-terra",
+    }],
+  }, { mode: "experts", rules: rules as any });
+  assert.equal(out.tasks?.[0]?.model, "sub2-responses/gpt-5.6-terra");
+});
+
+test("A4 ensureExpertsDispatch applies project roster profile", () => {
+  const cwd = tempCwd();
+  fs.writeFileSync(path.join(cwd, ".experts-rules.json"), JSON.stringify({
+    channels: { cpa: "cpa-responses" },
+    roster: {
+      explorer: {
+        agent: "explorer",
+        defaultTaskType: "explore",
+        channel: "cpa",
+        model: "deepseek-v4-flash",
+        thinking: "low",
+        skills: ["smart-search-cli"],
+      },
+    },
+  }, null, 2));
+  clearRulesCache();
+  setMode("experts", cwd);
+  const rules = loadRules(defaultRulesPath(), cwd);
+  const out = ensureExpertsDispatch({
+    tasks: [{ prompt: "搜索 PositionManager 调用链" }],
+  } as TeammateParamsLike, { cwd, mode: "experts", record: false, rules });
+  assert.equal(out.tasks?.[0]?.taskType, "explore");
+  assert.equal(out.tasks?.[0]?.agent, "explorer");
+  assert.equal(out.tasks?.[0]?.model, "cpa-responses/deepseek-v4-flash");
+  assert.equal(out.tasks?.[0]?.thinking, "low");
+  assert.match(String(out.tasks?.[0]?.prompt), new RegExp(EXPERTS_SKILLS_START));
+  clearRulesCache();
+});
+
+test("A4 resolveExpertProfile maps agent to profile", () => {
+  const rules = {
+    channels: { cpa: "cpa-responses" },
+    roster: {
+      planner: {
+        agent: "planner",
+        defaultTaskType: "planning",
+        channel: "cpa",
+        model: "grok-4.5",
+        skills: ["maestro"],
+      },
+    },
+  };
+  const p = resolveExpertProfile({ agent: "planner" }, rules as any);
+  assert.ok(p);
+  assert.equal(p!.model, "cpa-responses/grok-4.5");
+  assert.deepEqual(p!.skills, ["maestro"]);
 });

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -30,6 +30,12 @@ import {
   hasDangerousShellMetachar,
   mergeRules,
   mergeRosterMaps,
+  trackInFlight,
+  settleInFlight,
+  getInFlight,
+  clearInFlight,
+  withStateLock,
+  mutateJsonStateFile,
   type TeammateParamsLike,
 } from "../src/experts-mode/index.ts";
 
@@ -559,15 +565,7 @@ test("P5 normal mode never denies", () => {
 });
 
 // --- P6 roster + observability ---
-import {
-  resolveRosterEntry,
-  agentForTaskTypeFromRoster,
-  buildCanvasSnapshot,
-  getInFlight,
-  trackInFlight,
-  settleInFlight,
-  clearInFlight,
-} from "../src/experts-mode/index.ts";
+import { resolveRosterEntry, agentForTaskTypeFromRoster, buildCanvasSnapshot } from "../src/experts-mode/index.ts";
 
 test("P6 getRoster returns default roles without models", () => {
   clearRulesCache();
@@ -1648,4 +1646,100 @@ test("A6 HV-04 writing .experts-mode.json is not path-allowlisted", () => {
   });
   assert.equal(gate.decision, "deny");
   clearRulesCache();
+});
+
+
+// --- A7 residual audit HV-03 / MV-02 / MV-03 / MV-04 ---
+
+test("A7 HV-03 ensureExpertsDispatch records waitingDelta and settle clears", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const out = ensureExpertsDispatch(
+    { tasks: [{ prompt: "实现 feature", name: "dev-a" }, { prompt: "实现 feature2", name: "dev-b" }] },
+    { cwd, mode: "experts", record: true },
+  ) as any;
+  assert.equal(out.__experts?.waitingDelta, 2);
+  assert.equal(getLeaderWaiting(cwd).activeCount, 2);
+  noteExpertsSettled(cwd, { settledCount: out.__experts.waitingDelta, reason: "sim-early-return" });
+  assert.equal(getLeaderWaiting(cwd).activeCount, 0);
+  assert.equal(getLeaderWaiting(cwd).leaderWaiting, false);
+  clearRulesCache();
+});
+
+test("A7 MV-04 settleInFlight prefers id/name and does not wipe peer agent", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  trackInFlight([
+    { id: "dev-a", name: "dev-a", agent: "general-executor" },
+    { id: "dev-b", name: "dev-b", agent: "general-executor" },
+  ], { cwd });
+  // settle by agent once — only one entry removed
+  settleInFlight("general-executor", { cwd });
+  let list = getInFlight(cwd);
+  assert.equal(list.length, 1);
+  // settle remaining by name
+  settleInFlight("dev-b", { cwd });
+  list = getInFlight(cwd);
+  // after agent fallback removed first, remaining id is dev-b
+  assert.ok(list.length <= 1);
+  settleInFlight(["dev-a", "dev-b"], { cwd });
+  assert.equal(getInFlight(cwd).length, 0);
+  clearRulesCache();
+});
+
+test("A7 MV-04 exact name settles only that task", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  trackInFlight([
+    { id: "t1", name: "t1", agent: "general-executor" },
+    { id: "t2", name: "t2", agent: "general-executor" },
+  ], { cwd });
+  settleInFlight("t1", { cwd });
+  const list = getInFlight(cwd);
+  assert.equal(list.length, 1);
+  assert.equal(list[0]?.id, "t2");
+  clearRulesCache();
+});
+
+test("A7 MV-02 mutateJsonStateFile serializes RMW increments", async () => {
+  const cwd = tempCwd();
+  const file = path.join(cwd, ".experts-mode.json");
+  fs.writeFileSync(file, JSON.stringify({ n: 0 }, null, 2));
+  // sequential under lock
+  for (let i = 0; i < 20; i++) {
+    mutateJsonStateFile(file, (prev) => ({ ...prev, n: (Number(prev.n) || 0) + 1 }));
+  }
+  const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+  assert.equal(raw.n, 20);
+  // async lock also works
+  await Promise.all(
+    Array.from({ length: 10 }, () =>
+      withStateLock(file, async () => {
+        const prev = JSON.parse(fs.readFileSync(file, "utf8"));
+        const next = { ...prev, n: (Number(prev.n) || 0) + 1 };
+        fs.writeFileSync(file, JSON.stringify(next, null, 2));
+      }),
+    ),
+  );
+  const raw2 = JSON.parse(fs.readFileSync(file, "utf8"));
+  assert.equal(raw2.n, 30);
+});
+
+test("A7 MV-03 proxy path calls ensureExpertsDispatch before applyModelRouting", () => {
+  const src = fs.readFileSync(
+    path.join(process.cwd(), "src/extension/teammate-proxy.ts"),
+    "utf8",
+  );
+  const ensureIdx = src.indexOf("ensureExpertsDispatch(p");
+  const routeIdx = src.indexOf("applyModelRouting(\n        prepared");
+  // fallback if formatting differs
+  const routeIdx2 = src.indexOf("applyModelRouting(");
+  assert.ok(ensureIdx > 0, "proxy must call ensureExpertsDispatch");
+  const route = routeIdx > 0 ? routeIdx : src.indexOf("applyModelRouting(\n        prepared,");
+  // find applyModelRouting after prepared
+  const preparedRoute = src.indexOf("applyModelRouting", ensureIdx);
+  assert.ok(preparedRoute > ensureIdx, "ensure must precede applyModelRouting");
 });

--- a/packages/pi-maestro-teammate/test/experts-mode.test.ts
+++ b/packages/pi-maestro-teammate/test/experts-mode.test.ts
@@ -26,6 +26,7 @@ import {
   loadRules,
   clearRulesCache,
   EXPERTS_SKILLS_START,
+  getRoster,
   type TeammateParamsLike,
 } from "../src/experts-mode/index.ts";
 
@@ -555,7 +556,6 @@ test("P5 normal mode never denies", () => {
 
 // --- P6 roster + observability ---
 import {
-  getRoster,
   resolveRosterEntry,
   agentForTaskTypeFromRoster,
   buildCanvasSnapshot,
@@ -1455,4 +1455,33 @@ test("A4 resolveExpertProfile maps agent to profile", () => {
   assert.ok(p);
   assert.equal(p!.model, "cpa-responses/grok-4.5");
   assert.deepEqual(p!.skills, ["maestro"]);
+});
+
+
+test("A5 default roster preloads Maestro skills", () => {
+  clearRulesCache();
+  const roster = getRoster(loadRules(defaultRulesPath(), tempCwd()));
+  const byId = Object.fromEntries(roster.map((e) => [e.id, e]));
+  assert.deepEqual(byId.planner?.skills, ["maestro", "maestro-next"]);
+  assert.deepEqual(byId.analyst?.skills, ["maestro-spec"]);
+  assert.deepEqual(byId["general-executor"]?.skills, ["maestro-companion"]);
+  assert.deepEqual(byId.reviewer?.skills, ["team-review", "maestro-knowledge"]);
+  assert.deepEqual(byId.verifier?.skills, ["maestro-session-seal", "maestro-knowledge"]);
+  assert.deepEqual(byId.workflow?.skills, ["maestro-ralph", "team-coordinate"]);
+  // explorer: empty array or undefined/empty — no maestro-learn
+  const ex = byId.explorer?.skills ?? [];
+  assert.ok(!ex.includes("maestro-learn"));
+});
+
+test("A5 planner dispatch injects maestro skill guidance", () => {
+  clearRulesCache();
+  const cwd = tempCwd();
+  setMode("experts", cwd);
+  const rules = loadRules(defaultRulesPath(), cwd);
+  const out = ensureExpertsDispatch({
+    tasks: [{ prompt: "制定实现 JWT 的方案与拆分", agent: "planner", taskType: "planning" }],
+  } as TeammateParamsLike, { cwd, mode: "experts", record: false, rules });
+  assert.match(String(out.tasks?.[0]?.prompt), /experts-skills:start/);
+  assert.match(String(out.tasks?.[0]?.prompt), /maestro-next|maestro/);
+  clearRulesCache();
 });


### PR DESCRIPTION
## Summary
Adds **Experts Mode** as an **opt-in policy layer** over existing Pi teammate + Maestro Session/Run (not a second orchestrator).

### Highlights
- Stage policies → `taskType` pipelines; `ensureExpertsDispatch` before `applyModelRouting`
- Lead hard-gate (write/edit/bash deny in experts) + rewriteSuggestion
- Roster / waiting / harvest CLI + TUI overlay; `/experts` skill
- Per-role model/channel/skills profiles (`.experts-rules.json`)
- Maestro skills preload on default roster
- 81 tests in `packages/pi-maestro-teammate/test/experts-mode.test.ts`

### Non-goals
- No second Session/Run type
- No auto-teammate on `session next` (birth-only)
- role ≠ model (never invent model ids from role names)

### Commits (on `feat/experts-mode`)
1. Experts Mode P0–P7b + hygiene seal
2. Deep Maestro bind + `/experts` skill
3. CLI roster|waiting|harvest + TUI panel
4. Per-expert model/channel/skills profiles
5. Preload Maestro skills on roster defaults

### Test plan
- [ ] `cd packages/pi-maestro-teammate && npm test` (or experts-mode suite)
- [ ] `/experts on` → `/experts roster` → dispatch with `taskType`
- [ ] Lead hard-gate blocks business path write in experts mode

> Community contribution from fork [Smith-106/pi-maestro-flow](https://github.com/Smith-106/pi-maestro-flow). Happy to split/rework if maintainers prefer a different packaging boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Experts Mode with stage-aware routing, specialized profiles, configurable pipelines, and coordinated dispatch.
  * Added `/experts` status, roster, waiting, and harvest views, plus a read-only status overlay.
  * Added Maestro stage synchronization and automatic workflow context.
  * Added knowledge harvesting with deduplication and staged self-evolution suggestions.
  * Added project-level configuration and public Experts Mode access.
* **Bug Fixes**
  * Improved task classification and consistent development-task labeling.
  * Added safeguards for restricted tools and safer shell commands.
* **Tests**
  * Added comprehensive coverage for routing, persistence, safeguards, harvesting, status views, and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->