### PR TITLE
fix(compaction): block+terminate at hard tool boundary instead of abort()

### DIFF
--- a/packages/pi-maestro-flow/src/compaction/auto-compaction.ts
+++ b/packages/pi-maestro-flow/src/compaction/auto-compaction.ts
@@ -369,6 +369,21 @@ export function commitProjectedCompactionInput(
   event.preparation.turnPrefixMessages = projected.event.preparation.turnPrefixMessages;
 }
 
+/**
+ * Result returned to the host tool_call hook when hard-threshold pressure must
+ * stop further tool execution. `block` prevents the current tool; `terminate`
+ * ends the entire batch once every remaining call is likewise blocked, so the
+ * agent loop reaches agent_end/agent_settled without aborting the run.
+ */
+export interface ToolBoundaryGateResult {
+  block: true;
+  terminate: true;
+  reason: string;
+}
+
+const TOOL_BOUNDARY_BLOCK_REASON =
+  "Tool execution deferred: context crossed the hard compaction threshold. Compaction will run next; the task resumes automatically.";
+
 /** Snapshot of the mid-turn compaction module state for diagnostics (/compaction-status). */
 export interface MidTurnCompactionStatus {
   turnCount: number;
@@ -394,17 +409,22 @@ export interface MidTurnCompactionStatus {
 export function createMidTurnAutoCompaction(pi: ExtensionAPI, dependencies: AutoCompactionDependencies = {}): {
   onSessionStart(ctx: ExtensionContext, event?: { reason?: string }): void;
   evaluate(messages: AgentMessage[], ctx: ExtensionContext): Promise<AgentMessage[] | undefined>;
-  /** Interrupt a tool loop at the first tool boundary after the hard threshold is crossed. */
-  onToolCall(ctx: ExtensionContext): boolean;
+  /**
+   * Gate tool execution at the first hard-threshold boundary. Returns a
+   * ToolCallEventResult that blocks (and terminates) the batch so the agent
+   * loop settles cleanly — never abort(), which surfaces as
+   * "This operation was aborted" and can strand the resume path.
+   */
+  onToolCall(ctx: ExtensionContext): ToolBoundaryGateResult | undefined;
   projectCompactionInput(event: SessionBeforeCompactEvent, ctx: ExtensionContext): Promise<ProjectedCompactionInput>;
   beforeProviderRequest(payload: unknown, ctx: ExtensionContext): Promise<unknown | undefined>;
   shouldSkipStopHook(): boolean;
   isProviderPressureRecoveryActive(): boolean;
   /**
    * True while a synthetic interruption (provider-pressure replay or
-   * loop-critical abort) owns the current settlement. Root Goal/Stop
-   * lifecycle must treat such settlements as recovery, never as ordinary
-   * turn endings.
+   * loop-critical tool-boundary gate) owns the current settlement. Root
+   * Goal/Stop lifecycle must treat such settlements as recovery, never as
+   * ordinary turn endings.
    */
   isSyntheticCompactionInterruptionActive(): boolean;
   /**
@@ -1529,6 +1549,18 @@ export function createMidTurnAutoCompaction(pi: ExtensionAPI, dependencies: Auto
       });
     },
     onToolCall(ctx) {
+      // Once a tool-boundary gate is live, every subsequent tool in the same
+      // batch must also block+terminate so the host ends the batch cleanly
+      // (shouldTerminateToolBatch requires every finalized result.terminate).
+      // Do not abort(): that surfaces as "This operation was aborted" and can
+      // strand the resume path if the next provider turn inherits the signal.
+      if (state.loopCriticalBlocked && state.pendingIntent?.loopCritical) {
+        return {
+          block: true as const,
+          terminate: true as const,
+          reason: TOOL_BOUNDARY_BLOCK_REASON,
+        };
+      }
       const currentSettings = settingsFor(ctx);
       const snapshot = currentSettings.enabled
         && state.latestThreshold?.generation === state.generation
@@ -1578,24 +1610,30 @@ export function createMidTurnAutoCompaction(pi: ExtensionAPI, dependencies: Auto
         }
       }
       if (!intent || state.running || intent.requestBlocked || intent.loopCritical
-        || intent.estimate.tokens <= intent.linkedThreshold.thresholdTokens) return false;
-      // Abort at the tool boundary, then let agent_settled submit through the
+        || intent.estimate.tokens <= intent.linkedThreshold.thresholdTokens) return undefined;
+      // Block at the tool boundary, then let agent_settled submit through the
       // existing arbiter-owned compaction path. Calling compact() directly from
       // this hook would race the active agent loop and bypass recovery state.
-      if (state.zombieOwner !== undefined) return false;
-      if (dependencies.arbiter?.currentOwner()) return false;
-      if (dependencies.arbiter?.timeoutTombstone()) return false;
-      if (!compactionBreakerAllows(state.breaker, state.turnCount).allowed) return false;
+      // Prefer block+terminate over abort() so the host records a clean tool
+      // error ("Tool execution deferred…") instead of a run-level abort that
+      // surfaces as "This operation was aborted" and can strand resume.
+      if (state.zombieOwner !== undefined) return undefined;
+      if (dependencies.arbiter?.currentOwner()) return undefined;
+      if (dependencies.arbiter?.timeoutTombstone()) return undefined;
+      if (!compactionBreakerAllows(state.breaker, state.turnCount).allowed) return undefined;
       intent.loopCritical = true;
       state.loopCriticalBlocked = true;
       persistPendingIntent(pi, state);
-      ctx.abort();
       notifyPressureOnce(
         ctx,
         `tool-call-hard-threshold:${intent.linkedThreshold.thresholdTokens}`,
         `Context crossed the hard compaction threshold at a tool boundary (${intent.estimate.tokens.toLocaleString("en-US")}/${intent.linkedThreshold.thresholdTokens.toLocaleString("en-US")} tokens). Interrupting to compact before the tool runs; the task resumes automatically.`,
       );
-      return true;
+      return {
+        block: true as const,
+        terminate: true as const,
+        reason: TOOL_BOUNDARY_BLOCK_REASON,
+      };
     },
     async projectCompactionInput(event, ctx) {
       const generation = state.generation;

--- a/packages/pi-maestro-flow/src/extension/index.ts
+++ b/packages/pi-maestro-flow/src/extension/index.ts
@@ -2827,10 +2827,10 @@ Examples: { argv: ["session","status"] }, { argv: ["run","done","run-abc","--ver
   });
 
   // A hard-threshold intent must settle before the next tool executes. The
-  // guard aborts the active loop here; agent_settled owns the actual compact().
-  pi.on("tool_call", (_event, ctx) => {
-    midTurnAutoCompaction.onToolCall(ctx);
-  });
+  // guard blocks (+ terminates) the tool batch here without abort(); agent_settled
+  // owns the actual compact() and CONTINUE resume. Returning block/terminate
+  // avoids the host "This operation was aborted" error that stranded recovery.
+  pi.on("tool_call", (_event, ctx) => midTurnAutoCompaction.onToolCall(ctx));
 
   // Keep the tool panel stable for prompt-cache reuse; this hook enforces the hard
   // read-only boundary until Plan approval, before the interactive permission chain.
@@ -3283,9 +3283,8 @@ function registerMaestroChildSurface(pi: ExtensionAPI): void {
     compactionArbiter.reset();
     autoCompaction.onSessionStart(ctx, event);
   });
-  pi.on("tool_call", (_event, ctx) => {
-    autoCompaction.onToolCall(ctx);
-  });
+  // Child sessions share the same hard-threshold gate: block+terminate, never abort.
+  pi.on("tool_call", (_event, ctx) => autoCompaction.onToolCall(ctx));
   pi.on("context", async (event, ctx) => {
     try {
       const messages = await autoCompaction.evaluate(event.messages, ctx);

--- a/packages/pi-maestro-flow/test/compaction.test.ts
+++ b/packages/pi-maestro-flow/test/compaction.test.ts
@@ -3927,16 +3927,25 @@ test("the first tool call after the hard threshold interrupts and compacts at se
   assert.ok(pending.tokens > pending.thresholdTokens);
   assert.equal(fx.aborted(), 0, "the context hook only records the hard-threshold intent");
 
-  assert.equal(fx.guard.onToolCall(fx.ctx), true);
-  assert.equal(fx.guard.onToolCall(fx.ctx), false, "parallel tool-call hooks cannot interrupt twice");
-  assert.equal(fx.aborted(), 1, "the tool is interrupted before execution");
+  const gate = fx.guard.onToolCall(fx.ctx);
+  assert.deepEqual(gate, {
+    block: true,
+    terminate: true,
+    reason: "Tool execution deferred: context crossed the hard compaction threshold. Compaction will run next; the task resumes automatically.",
+  }, "the first tool is blocked+terminated instead of aborting the run");
+  assert.deepEqual(
+    fx.guard.onToolCall(fx.ctx),
+    gate,
+    "remaining tools in the same batch keep blocking so the host can terminate cleanly",
+  );
+  assert.equal(fx.aborted(), 0, "the tool boundary gate never aborts the run");
   assert.equal(fx.guard.describeState().pendingIntent?.loopCritical, true);
   assert.ok(
     fx.notifications.some(({ message }) => /hard compaction threshold at a tool boundary/.test(message)),
     "the immediate compaction reason is visible",
   );
 
-  // The aborted tool result runs the context hook again with a new trigger key.
+  // The blocked tool result runs the context hook again with a new trigger key.
   // That refresh must retain the synthetic interruption through settlement.
   await fx.guard.evaluate(highUsageToolBatch(365_001), fx.ctx);
   assert.equal(fx.guard.describeState().pendingIntent?.loopCritical, true);
@@ -3947,17 +3956,19 @@ test("the first tool call after the hard threshold interrupts and compacts at se
   assert.match(fx.sent.at(-1) ?? "", /Continue the interrupted task/, "compaction resumes the interrupted tool loop");
 });
 
-test("a tool-boundary abort survives post-abort pressure relief and resumes after compaction", async () => {
+test("a tool-boundary gate survives post-block pressure relief and resumes after compaction", async () => {
   const fx = loopCriticalFixture();
   await fx.guard.evaluate(highUsageToolBatch(365_000), fx.ctx);
-  assert.equal(fx.guard.onToolCall(fx.ctx), true);
-  assert.equal(fx.aborted(), 1);
+  const gate = fx.guard.onToolCall(fx.ctx);
+  assert.equal(gate?.block, true);
+  assert.equal(gate?.terminate, true);
+  assert.equal(fx.aborted(), 0, "tool-boundary gate does not abort the run");
 
-  // The aborted tool result can be much smaller after stable pruning. That
+  // The blocked tool result can be much smaller after stable pruning. That
   // frame must not erase the interruption before agent_settled submits it.
   await fx.guard.evaluate(highUsageToolBatch(200_000), fx.ctx);
   const pending = fx.guard.describeState().pendingIntent;
-  assert.ok(pending, "the aborted request remains pending below the threshold");
+  assert.ok(pending, "the gated request remains pending below the threshold");
   assert.equal(pending.loopCritical, true);
 
   await fx.guard.onAgentEnd(fx.ctx);
@@ -3975,12 +3986,14 @@ test("tool-call usage creates a hard-threshold intent when the context frame cou
   await fx.guard.evaluate([{ role: "user", content: "continue" }] as never, fx.ctx);
   assert.equal(fx.guard.describeState().pendingIntent, undefined, "an incomplete tool-result frame skips pressure policy");
 
-  assert.equal(fx.guard.onToolCall(fx.ctx), true);
+  const gate = fx.guard.onToolCall(fx.ctx);
+  assert.equal(gate?.block, true);
+  assert.equal(gate?.terminate, true);
   const pending = fx.guard.describeState().pendingIntent;
   assert.ok(pending);
   assert.equal(pending.tokens, 365_000);
   assert.equal(pending.thresholdTokens, 360_000);
-  assert.equal(fx.aborted(), 1);
+  assert.equal(fx.aborted(), 0, "usage-derived hard threshold blocks tools without aborting");
 
   await fx.guard.onAgentEnd(fx.ctx);
   assert.equal(fx.compactCalls.length, 1, "usage-derived pressure compacts at the same settlement");
@@ -4024,11 +4037,13 @@ test("usage-derived intent judges exhaustion against the active session window",
   } as never;
 
   await guard.evaluate([{ role: "user", content: "continue" }] as never, ctx);
-  assert.equal(guard.onToolCall(ctx), true);
+  const gate = guard.onToolCall(ctx);
+  assert.equal(gate?.block, true);
+  assert.equal(gate?.terminate, true);
   const pending = guard.describeState().pendingIntent;
   assert.ok(pending);
   assert.equal(pending.contextExhausted, false, "the smaller summary window is a trigger limiter, not the provider limit");
-  assert.equal(aborted, 1);
+  assert.equal(aborted, 0, "tool-boundary gating does not abort the run");
 });
 
 test("usage exactly at the hard threshold does not interrupt a tool call", async () => {
@@ -4038,7 +4053,7 @@ test("usage exactly at the hard threshold does not interrupt a tool call", async
   });
   await fx.guard.evaluate([{ role: "user", content: "continue" }] as never, fx.ctx);
 
-  assert.equal(fx.guard.onToolCall(fx.ctx), false);
+  assert.equal(fx.guard.onToolCall(fx.ctx), undefined);
   assert.equal(fx.aborted(), 0);
   assert.equal(fx.guard.describeState().pendingIntent, undefined);
 });
@@ -4047,7 +4062,9 @@ test("hard-threshold tool calls compact before queued messages without duplicate
   const fx = loopCriticalFixture({ hasPendingMessages: () => true });
   await fx.guard.evaluate(highUsageToolBatch(365_000), fx.ctx);
 
-  assert.equal(fx.guard.onToolCall(fx.ctx), true, "hard pressure takes priority over the queued-message shortcut");
+  const gate = fx.guard.onToolCall(fx.ctx);
+  assert.equal(gate?.block, true, "hard pressure takes priority over the queued-message shortcut");
+  assert.equal(gate?.terminate, true);
   await fx.guard.onAgentEnd(fx.ctx);
   assert.equal(fx.compactCalls.length, 1);
   fx.compactCalls[0].onComplete();
@@ -4193,7 +4210,7 @@ test("loop-critical flag survives persistence and legacy intents hydrate without
   });
   disabled.onSessionStart(disabledCtx, { reason: "resume" });
   assert.ok(disabled.describeState().pendingIntent, "the persisted intent is visible before current settings are checked");
-  assert.equal(disabled.onToolCall(disabledCtx), false);
+  assert.equal(disabled.onToolCall(disabledCtx), undefined);
   assert.equal(disabledAborts, 0, "disabled compaction cannot interrupt the resumed task");
   assert.equal(disabled.describeState().pendingIntent, undefined, "the stale intent is cleared before tool execution");
 });


### PR DESCRIPTION
## Summary

Hard-threshold interruption at a **tool boundary** currently calls `ctx.abort()`.
That surfaces in the host UI as:

```text
Warning: Context crossed the hard compaction threshold at a tool boundary
         (…/… tokens). Interrupting to compact before the tool runs; the task
         resumes automatically.

Error: This operation was aborted
```

even though the intended path is: interrupt tools → settle → mid-turn compact →
auto-continue. The abort is extension-owned, not a user cancel.

## Problem

In `createMidTurnAutoCompaction().onToolCall`, when estimated context is strictly
above the linked hard threshold, the guard:

1. marks `pendingIntent.loopCritical = true`
2. sets `loopCriticalBlocked`
3. calls **`ctx.abort()`**
4. relies on `agent_settled` → `settlePendingCompaction` → `CONTINUE_PROMPT`

Pi’s agent loop / UI treat abort as a run-level failure (`AbortError` /
“This operation was aborted”). That:

- looks like a broken turn to the user
- can race or strand recovery if a later provider turn inherits the aborted signal
- contradicts the user-facing promise that “the task resumes automatically”

Soft pruning / nudge settings do not fix this; the hard path always used `abort()`.

## Root cause

| Layer | Behavior |
|---|---|
| **pi-maestro-flow** | Intentionally interrupts at tool boundary for hard pressure |
| **Pi host** | Correctly renders `abort()` as an aborted/error run |

So this is not a host mis-display of an unrelated failure; it is the hard-gate
implementation choice (`abort` vs clean tool denial).

## Fix

Stop calling `ctx.abort()` on the hard tool-boundary path. Instead return a
`tool_call` handler result:

```ts
{
  block: true,
  terminate: true,
  reason: "Tool execution deferred: context crossed the hard compaction threshold. …"
}
```

Rationale (matches Pi’s tool batch semantics):

- `block` prevents the current tool from executing
- `terminate` must be set on **every** finalized result in the batch for
  `shouldTerminateToolBatch` to end the batch cleanly
- once `loopCriticalBlocked` is live, **subsequent** tools in the same batch also
  return the same gate so the host can terminate without aborting the run
- `agent_settled` still owns `compact()` + `CONTINUE_PROMPT` (unchanged)

Also wire root/child extension `tool_call` handlers to **return** the gate result
(not fire-and-forget), so the host actually receives `block` / `terminate`.

## Behavior change

| Before | After |
|---|---|
| Tool boundary → `ctx.abort()` | Tool boundary → `block` + `terminate` |
| UI: `Error: This operation was aborted` | UI: blocked tool reason + hard-threshold warning |
| Run looks cancelled | Run settles cleanly, then compact + continue |

Unchanged:

- hard threshold formula / linked threshold
- arbiter ownership of mid-turn compact
- `CONTINUE_PROMPT` / retry prompts after successful compact
- loop-critical **context-hook** path that still uses abort for sustained
  critical-band pressure *inside* an active loop (optional follow-up: align that
  path the same way)

## Files

- `packages/pi-maestro-flow/src/compaction/auto-compaction.ts`
- `packages/pi-maestro-flow/src/extension/index.ts`
- `packages/pi-maestro-flow/test/compaction.test.ts`

## Test plan

- [x] `npm run test:compaction` — 355 pass / 0 fail (1 skipped)
- [x] tool-boundary cases assert `block`/`terminate` and `aborted === 0`
- [ ] Manual: long session above hard threshold at a tool call → deferred tool reason, no run-level abort error, compact + auto-continue

## Notes for reviewers

- Small PR off `master` only.
- API surface: `onToolCall` return type becomes `ToolBoundaryGateResult | undefined`
  instead of `boolean` (in-tree extension wiring only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic compaction at tool-call boundaries to prevent interrupted runs.
  * Hard-limit tool calls now stop cleanly and allow pending work to settle before recovery.
  * Repeated tool calls are handled consistently during compaction.
  * Calls at the exact usage threshold continue without interruption.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->