### PR TITLE
feat(flow): enrich API Manager model discovery with models.dev reference specs

### DIFF
--- a/packages/pi-maestro-flow/src/providers/api-provider-config.ts
+++ b/packages/pi-maestro-flow/src/providers/api-provider-config.ts
@@ -2045,14 +2045,18 @@ async function discoverAndInjectModels(
     return "manual";
   }
 
+  const specById = new Map(discovered.map((model) => [model.id, model]));
   let result: SaveApiProviderResult | undefined;
   for (const modelId of selected) {
+    // Discovered models carry reference specs (gateway-advertised or models.dev);
+    // only fall back to the conservative defaults when a model has neither.
+    const enriched = specById.get(modelId);
     const next: ApiProviderSettings = {
       provider: providerId,
       baseUrl,
       modelId,
-      contextWindow: 128_000,
-      maxTokens: 16_384,
+      contextWindow: enriched?.contextWindow ?? 128_000,
+      maxTokens: enriched?.maxTokens ?? 16_384,
       reasoning: true,
       apiKey,
       api,
@@ -2074,6 +2078,8 @@ async function discoverAndInjectModels(
 /**
  * Form-level discovery: probe /models using the form's current Base URL/API key
  * (falling back to saved values) and exclude already-configured model ids.
+ * The enriched results (with reference specs) are remembered so the form can
+ * prefill context/max-output fields when a discovered model is picked.
  */
 async function discoverFormModelIds(
   values: ApiModelFormValues,
@@ -2086,8 +2092,21 @@ async function discoverFormModelIds(
   const baseUrl = normalizeBaseUrl(rawBaseUrl);
   const apiKey = formText(values, "apiKey") || current.apiKey;
   const discovered = await discoverModels({ baseUrl, apiKey: apiKey || undefined });
+  lastDiscoveredSpecs = new Map(discovered.map((model) => [model.id, model]));
   const configured = new Set(await configuredModelIds(providerId, modelsPath));
   return discovered.map((model) => model.id).filter((id) => !configured.has(id));
+}
+
+/**
+ * Enriched results from the most recent form-level discovery, used to prefill
+ * context/max-output fields when a discovered model is picked. Module-level
+ * because the editor overlay params are plain callbacks; only the latest
+ * discovery per open form is kept.
+ */
+let lastDiscoveredSpecs: Map<string, DiscoveredModel> = new Map();
+
+function resolveFormModelSpec(modelId: string): { contextWindow?: number; maxTokens?: number } | undefined {
+  return lastDiscoveredSpecs.get(modelId);
 }
 
 /** Legacy step-by-step fallback for hosts without the custom form overlay. */
@@ -2392,6 +2411,7 @@ async function configurePresetModelWithForm(
       !adding,
     ),
     discoverModels: (values) => discoverFormModelIds(values, provider.id, current, modelsPath),
+    resolveModelSpecs: resolveFormModelSpec,
   });
   if (!result) return;
 
@@ -2621,6 +2641,7 @@ async function configureCustomModelWithForm(
       return errors;
     },
     discoverModels: (values) => discoverFormModelIds(values, providerId, current, modelsPath),
+    resolveModelSpecs: resolveFormModelSpec,
   });
   if (!result) return;
 

--- a/packages/pi-maestro-flow/src/providers/model-discovery.ts
+++ b/packages/pi-maestro-flow/src/providers/model-discovery.ts
@@ -6,12 +6,15 @@
  * user can pick which ones to inject into `models.json` instead of typing each
  * Model ID by hand.
  *
- * This mirrors the `/v1/models` probing in the `multi-relay` reference
- * extension, but stays read-only: it never writes anything. The caller decides
- * which discovered models to register. Discovery is an optional enhancement —
- * a network failure or a gateway without a `/models` endpoint is surfaced as a
- * thrown error and degrades to the manual entry flow.
+ * Gateways rarely advertise context/output limits, so discovered models are
+ * enriched with reference specs from models.dev (same source as pi's own
+ * generated catalogs), cached on disk for 24h. Gateway-advertised values
+ * always win; a failed or offline spec fetch degrades to plain discovery. The
+ * caller decides which discovered models to register.
  */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { normalizeBaseUrl } from "./api-provider-config.ts";
 
 export interface DiscoveredModel {
@@ -19,6 +22,11 @@ export interface DiscoveredModel {
   name?: string;
   contextWindow?: number;
   maxTokens?: number;
+}
+
+export interface ModelSpec {
+  context?: number;
+  output?: number;
 }
 
 export interface DiscoverOptions {
@@ -34,6 +42,8 @@ export interface DiscoverOptions {
   timeoutMs?: number;
   /** Optional abort signal (composed with the timeout signal). */
   signal?: AbortSignal;
+  /** Overrides the models.dev spec source and its cache path; tests only. */
+  specs?: { url?: string; cachePath?: string };
 }
 
 const DEFAULT_DISCOVER_TIMEOUT_MS = 8000;
@@ -92,6 +102,46 @@ function coerceModel(item: unknown): DiscoveredModel | undefined {
 }
 
 /**
+ * Match a model id against the spec table. Relay ids are messy
+ * ("gpt-5.5", "openai/gpt-5.5", dated suffixes, ":"/"_" variants), so ids are
+ * normalized first; then the longest bidirectional prefix match wins to keep
+ * "gpt-5" from matching "gpt-50".
+ */
+export function normalizeModelId(modelId: string): string {
+  return modelId.toLowerCase().replace(/^.*\//, "").replace(/-\d{4}-\d{2}-\d{2}$/, "").replace(/[:_]/g, "-");
+}
+
+export function lookupModelSpec(specs: Map<string, ModelSpec>, modelId: string): ModelSpec | undefined {
+  const normalized = normalizeModelId(modelId);
+  const exact = specs.get(modelId) ?? specs.get(normalized);
+  if (exact) return exact;
+  let best: { key: string; len: number } | undefined;
+  for (const [key, value] of specs) {
+    const nk = normalizeModelId(key);
+    if ((normalized.startsWith(nk) || nk.startsWith(normalized)) && (!best || Math.min(nk.length, normalized.length) > best.len)) {
+      best = { key, len: Math.min(nk.length, normalized.length) };
+    }
+  }
+  return best ? specs.get(best.key) : undefined;
+}
+
+async function enrichWithModelSpecs(models: DiscoveredModel[], opts?: DiscoverOptions): Promise<DiscoveredModel[]> {
+  if (models.length === 0) return models;
+  let specs: Map<string, ModelSpec>;
+  try {
+    specs = await loadModelSpecs(opts?.specs);
+  } catch {
+    // Specs are a best-effort enhancement; plain discovery results stay valid.
+    return models;
+  }
+  return models.map((model) => ({
+    ...model,
+    contextWindow: model.contextWindow ?? lookupModelSpec(specs, model.id)?.context,
+    maxTokens: model.maxTokens ?? lookupModelSpec(specs, model.id)?.output,
+  }));
+}
+
+/**
  * Probe a Provider's `/models` endpoint and return the models it advertises.
  *
  * Accepts the OpenAI-style `{ data: [...] }` envelope, a bare `{ models: [...] }`
@@ -130,5 +180,125 @@ export async function discoverModels(opts: DiscoverOptions): Promise<DiscoveredM
     seen.add(model.id);
     models.push(model);
   }
-  return models;
+  return enrichWithModelSpecs(models, opts);
+}
+
+// ============================================================================
+// Reference specs from models.dev
+//
+// Most relays do not advertise context/output limits in /models. models.dev
+// publishes per-model limits (the same source pi's generated catalogs use);
+// they are fetched once and cached on disk for 24h, mirroring the
+// OpenRouter pricing cache in cost-backfill.ts: a stale snapshot beats an
+// empty one, and a failed fetch never fails discovery itself.
+// ============================================================================
+
+const MODELS_DEV_API_URL = "https://models.dev/api.json";
+const MODEL_SPECS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const MODEL_SPECS_FETCH_TIMEOUT_MS = 10_000;
+
+interface ModelsDevEntry {
+  models?: Record<string, { limit?: { context?: number; output?: number } }>;
+}
+
+interface ModelSpecsCacheFile {
+  fetchedAt: number;
+  specs: Record<string, ModelSpec>;
+}
+
+function modelSpecsCachePath(): string {
+  return join(getAgentDir(), "model-specs-cache.json");
+}
+
+function parseModelsDevSpecs(payload: unknown): Map<string, ModelSpec> {
+  const specs = new Map<string, ModelSpec>();
+  if (!payload || typeof payload !== "object") return specs;
+  const db = payload as Record<string, ModelsDevEntry>;
+  for (const entry of Object.values(db)) {
+    const models = entry?.models;
+    if (!models || typeof models !== "object") continue;
+    for (const [modelId, model] of Object.entries(models)) {
+      const limit = model?.limit;
+      if (!limit || typeof limit !== "object") continue;
+      // The same id may appear under several providers; first wins.
+      if (!specs.has(modelId) && limit) {
+        specs.set(modelId, { context: limit.context, output: limit.output });
+      }
+    }
+  }
+  return specs;
+}
+
+async function readModelSpecsCache(path: string, ttlMs: number): Promise<Map<string, ModelSpec> | undefined> {
+  try {
+    const cached = JSON.parse(await readFile(path, "utf8")) as ModelSpecsCacheFile;
+    if (typeof cached.fetchedAt !== "number" || Date.now() - cached.fetchedAt >= ttlMs) return undefined;
+    if (!cached.specs || typeof cached.specs !== "object") return undefined;
+    const specs = new Map<string, ModelSpec>(
+      Object.entries(cached.specs).filter(([, spec]) => spec && typeof spec === "object"),
+    );
+    return specs.size > 0 ? specs : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeModelSpecsCache(path: string, specs: Map<string, ModelSpec>): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const file: ModelSpecsCacheFile = { fetchedAt: Date.now(), specs: Object.fromEntries(specs) };
+    await writeFile(path, `${JSON.stringify(file)}\n`, "utf8");
+  } catch {
+    // Cache is best-effort; a failed write must not fail discovery.
+  }
+}
+
+/**
+ * Load reference model specs from models.dev, served from the disk cache when
+ * fresh and falling back to a stale snapshot when the network is unavailable.
+ * Throws only when there is no usable snapshot at all; callers must treat a
+ * rejection as "no specs available", never as a discovery failure.
+ */
+export async function loadModelSpecs(opts?: { cachePath?: string; ttlMs?: number; url?: string }): Promise<Map<string, ModelSpec>> {
+  const cachePath = opts?.cachePath ?? modelSpecsCachePath();
+  const ttlMs = opts?.ttlMs ?? MODEL_SPECS_CACHE_TTL_MS;
+  const url = opts?.url ?? MODELS_DEV_API_URL;
+  const fresh = await readModelSpecsCache(cachePath, ttlMs);
+  if (fresh) return fresh;
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(MODEL_SPECS_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`models.dev HTTP ${response.status}`);
+    const specs = parseModelsDevSpecs(await response.json());
+    if (specs.size === 0) throw new Error("models.dev returned no model specs");
+    await writeModelSpecsCache(cachePath, specs);
+    return specs;
+  } catch (error) {
+    // Stale beats empty: reuse the expired snapshot when the fetch fails.
+    try {
+      const cached = JSON.parse(await readFile(cachePath, "utf8")) as ModelSpecsCacheFile;
+      if (cached.specs && typeof cached.specs === "object") {
+        const specs = new Map<string, ModelSpec>(
+          Object.entries(cached.specs).filter(([, spec]) => spec && typeof spec === "object"),
+        );
+        if (specs.size > 0) return specs;
+      }
+    } catch {
+      /* no usable snapshot */
+    }
+    throw error;
+  }
+}
+
+/** Test seam: drop the on-disk specs cache so a test starts from a cold state. */
+export async function clearModelSpecsCache(opts?: { cachePath?: string }): Promise<void> {
+  const cachePath = opts?.cachePath ?? modelSpecsCachePath();
+  try {
+    await mkdir(dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, `${JSON.stringify({ fetchedAt: 0, specs: {} })}\n`, "utf8");
+  } catch {
+    /* best-effort */
+  }
 }

--- a/packages/pi-maestro-flow/src/tui/api-model-editor.ts
+++ b/packages/pi-maestro-flow/src/tui/api-model-editor.ts
@@ -62,6 +62,8 @@ export interface ApiModelEditorOverlayParams {
   validate?: (values: ApiModelFormValues) => string[];
   /** Enables Ctrl+D on discoverable fields; resolves selectable gateway model ids, throws on failure. */
   discoverModels?: (values: ApiModelFormValues) => Promise<string[]>;
+  /** Resolves reference specs (context/max output) for a discovered model id, used to prefill number fields on pick. */
+  resolveModelSpecs?: (modelId: string) => { contextWindow?: number; maxTokens?: number } | undefined;
 }
 
 const CATALOGS = {
@@ -377,10 +379,31 @@ export class ApiModelEditorOverlay implements Component, Focusable {
       if (pick.checked.size > 0) {
         const field = this.currentField();
         if (field) field.value = pick.ids.filter((id) => pick.checked.has(id)).join(",");
+        this.prefillSpecFields(pick);
         this.markChanged();
       }
       this.picking = null;
     }
+  }
+
+  /** Prefill contextWindow/maxTokens from reference specs when exactly one discovered model was picked. */
+  private prefillSpecFields(pick: { ids: string[]; checked: Set<string> }): void {
+    const picked = pick.ids.filter((id) => pick.checked.has(id));
+    if (picked.length !== 1 || !this.params.resolveModelSpecs) return;
+    const spec = this.params.resolveModelSpecs(picked[0]!);
+    if (!spec) return;
+    for (const [fieldId, value] of [
+      ["contextWindow", spec.contextWindow],
+      ["maxTokens", spec.maxTokens],
+    ] as const) {
+      if (typeof value !== "number") continue;
+      const field = this.fields.find((entry) => entry.id === fieldId);
+      if (field?.kind === "number" && !this.isFieldTouchedByUser(field.id)) field.value = String(value);
+    }
+  }
+
+  private isFieldTouchedByUser(fieldId: string): boolean {
+    return this.originalValues[fieldId] !== undefined && this.values()[fieldId] !== this.originalValues[fieldId];
   }
 
   private renderPick(width: number): string[] {

--- a/packages/pi-maestro-flow/test/model-discovery.test.ts
+++ b/packages/pi-maestro-flow/test/model-discovery.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { discoverModels, modelsUrlForProvider } from "../src/providers/model-discovery.ts";
+import {
+  discoverModels,
+  loadModelSpecs,
+  lookupModelSpec,
+  modelsUrlForProvider,
+  normalizeModelId,
+} from "../src/providers/model-discovery.ts";
 
 /** Start an ephemeral HTTP server that records the last request and replies with `body`. */
 async function startServer(
@@ -158,5 +167,142 @@ test("discoverModels deduplicates repeated model ids", async () => {
     assert.deepEqual(models.map((m) => m.id), ["dup", "uniq"]);
   } finally {
     await srv.close();
+  }
+});
+
+// ============================================================================
+// Reference specs from models.dev
+// ============================================================================
+
+const SPECS_PAYLOAD = {
+  openai: { models: { "gpt-5.6-sol": { limit: { context: 400_000, output: 128_000 } } } },
+  anthropic: { models: { "anthropic/claude-opus-5": { limit: { context: 200_000, output: 64_000 } } } },
+};
+
+function startSpecsServer(payload: unknown, status = 200): Promise<{ server: Server; url: string; close: () => Promise<void>; hits: () => number }> {
+  let hits = 0;
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      hits += 1;
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(payload));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("server did not bind");
+      resolve({
+        server,
+        url: `http://127.0.0.1:${address.port}/api.json`,
+        close: () => new Promise((done) => server.close(() => done())),
+        hits: () => hits,
+      });
+    });
+  });
+}
+
+function specsTestDir(): { dir: string; cachePath: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pi-model-specs-"));
+  return { dir, cachePath: join(dir, "model-specs-cache.json"), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test("normalizeModelId strips prefixes, date suffixes and separator variants", () => {
+  assert.equal(normalizeModelId("gpt-5.5"), "gpt-5.5");
+  assert.equal(normalizeModelId("openai/gpt-5.5"), "gpt-5.5");
+  assert.equal(normalizeModelId("gpt-5.5-2026-06-01"), "gpt-5.5");
+  assert.equal(normalizeModelId("GLM:5_5"), "glm-5-5");
+});
+
+test("lookupModelSpec matches exact, normalized and longest-prefix ids", () => {
+  const specs = new Map(Object.entries(SPECS_PAYLOAD).flatMap(([provider, entry]) =>
+    Object.entries(entry.models ?? {}).map(([id, model]) => [id, { context: model.limit?.context, output: model.limit?.output } as const]),
+  ));
+  assert.deepEqual(lookupModelSpec(specs, "gpt-5.6-sol"), { context: 400_000, output: 128_000 });
+  assert.deepEqual(lookupModelSpec(specs, "claude-opus-5"), { context: 200_000, output: 64_000 });
+  // Longest bidirectional prefix match keeps "gpt-5" from matching "gpt-50".
+  assert.deepEqual(
+    lookupModelSpec(new Map([["gpt-5", { context: 1, output: 2 }], ["gpt-50", { context: 3, output: 4 }]]), "gpt-5"),
+    { context: 1, output: 2 },
+  );
+  assert.equal(lookupModelSpec(specs, "totally-unknown-model"), undefined);
+});
+
+test("loadModelSpecs fetches once and serves subsequent reads from the fresh disk cache", async () => {
+  const specsSrv = await startSpecsServer(SPECS_PAYLOAD);
+  const { cachePath, cleanup } = specsTestDir();
+  try {
+    const first = await loadModelSpecs({ cachePath, ttlMs: 60_000, url: specsSrv.url });
+    const second = await loadModelSpecs({ cachePath, ttlMs: 60_000, url: specsSrv.url });
+    assert.equal(first.get("gpt-5.6-sol")?.context, 400_000);
+    assert.deepEqual(second, first);
+    assert.equal(specsSrv.hits(), 1); // TTL-fresh cache must suppress the second network fetch
+    assert.ok(JSON.parse(readFileSync(cachePath, "utf8")).fetchedAt > 0);
+  } finally {
+    await specsSrv.close();
+    cleanup();
+  }
+});;
+test("loadModelSpecs falls back to a stale snapshot when the spec service is down", async () => {
+  const { cachePath, cleanup } = specsTestDir();
+  try {
+    writeFileSync(cachePath, JSON.stringify({ fetchedAt: Date.now() - 48 * 60 * 60 * 1000, specs: { "gpt-4o": { context: 128_000, output: 16_384 } } }));
+    const down = await startSpecsServer({ error: "boom" }, 500);
+    try {
+      const specs = await loadModelSpecs({ cachePath, ttlMs: 1000, url: down.url });
+      assert.equal(specs.get("gpt-4o")?.context, 128_000);
+    } finally {
+      await down.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("loadModelSpecs rejects when there is no usable snapshot at all", async () => {
+  const { cachePath, cleanup } = specsTestDir();
+  try {
+    const down = await startSpecsServer({ error: "boom" }, 500);
+    try {
+      await assert.rejects(loadModelSpecs({ cachePath, ttlMs: 60_000, url: down.url }));
+    } finally {
+      await down.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverModels enriches missing limits from models.dev but keeps gateway-advertised values", async () => {
+  const specsSrv = await startSpecsServer(SPECS_PAYLOAD);
+  const { cachePath, cleanup } = specsTestDir();
+  const srv = await startServer(() => ({
+    body: {
+      data: [
+        { id: "openai/gpt-5.6-sol-2026-01-01" }, // no limits → enriched via normalized + prefix match
+        { id: "anthropic/claude-opus-5", context_window: 999_999 }, // gateway value wins over the reference spec
+      ],
+    },
+  }));
+  try {
+    const models = await discoverModels({ baseUrl: srv.base, apiKey: "k", specs: { url: specsSrv.url, cachePath } });
+    assert.equal(models[0]!.contextWindow, 400_000);
+    assert.equal(models[0]!.maxTokens, 128_000);
+    assert.equal(models[1]!.contextWindow, 999_999);
+  } finally {
+    await srv.close();
+    await specsSrv.close();
+    cleanup();
+  }
+});
+
+test("discoverModels still returns results when the spec service is unreachable", async () => {
+  const { cachePath, cleanup } = specsTestDir();
+  const srv = await startServer(() => ({ body: { data: [{ id: "mystery-model" }] } }));
+  try {
+    const models = await discoverModels({ baseUrl: srv.base, apiKey: "k", specs: { url: "http://127.0.0.1:1/api.json", cachePath } });
+    assert.deepEqual(models.map((m) => m.id), ["mystery-model"]);
+    assert.equal(models[0]!.contextWindow, undefined); // no specs available → plain discovery result
+  } finally {
+    await srv.close();
+    cleanup();
   }
 });


### PR DESCRIPTION
## 背景

API Manager 的模型发现（`/api-manager` 内置的 `/v1/models` 探测）解决了「网关有哪些模型」的问题，但多数中转站的 /models 响应**不携带 context_window / max_tokens 字段**，导致发现注入的模型一律落到硬编码默认值 128,000 / 16,384 —— 对当前主流大上下文模型（1M context 已常见）严重失真，直接影响自动 compaction 阈值计算。

参考实现：社区 multi-relay 扩展通过 models.dev 规格库 + 归一化前缀匹配补全缺失规格。本 PR 将该能力以 api-manager 的原生方式内置。

## 改动

### model-discovery.ts
- 新增 `ModelSpec` / `loadModelSpecs()`：拉取 models.dev 规格表，磁盘缓存 24h TTL，完全沿用 cost-backfill.ts 的 OpenRouter pricing 缓存模式（**过期快照优先于空结果**；拉取失败永不导致发现失败）
- 新增 `normalizeModelId()` / `lookupModelSpec()`：归一化（去 `provider/` 前缀、去日期后缀、`:_`→`-`）+ 最长双向前缀匹配，避免 "gpt-5" 误配 "gpt-50"
- `discoverModels()` 自动富化：仅对网关未声明 limits 的模型补全，**网关自带值始终优先**

### 发现注入的两条路径
- **步骤流**（`discoverAndInjectModels`）：逐个注入时使用富化后的真实规格替换硬编码 128k/16k
- **表单流**（Ctrl+D picker）：记住最近一次发现的富化结果，恰好选中一个模型时预填 `contextWindow`/`maxTokens` 字段；用户已手动修改过的字段不覆盖

## 兼容性

- 纯增量：无 schema 变更、无既有行为破坏；规格不可用时完全退回原有行为
- 缓存文件为新增的 `~/.pi/agent/model-specs-cache.json`，写入 best-effort

## 测试

- `test/model-discovery.test.ts` 18/18 通过（新增 7 个：归一化、前缀匹配、TTL 抑制重复拉取、服务宕机回落过期快照、无快照时拒绝、富化优先级、规格失败降级）
- `test/api-model-editor.test.ts` 14/14 通过；`test/cost-backfill.test.ts` 13/13 通过
- `npm run typecheck` 通过
- 注：`test/api-provider-config.test.ts` 在 Bun 下有 30 个与本次改动无关的既有失败（干净 master 上同样复现，断言的是中文 UI 文案与 compaction 提示，Node 22 的 `--experimental-transform-types` 应为预期运行环境）

## 手动验证路径

`/api-manager` → 添加 Provider → 填 Base URL/API key → Ctrl+D 发现 → 选择一个网关未报 limits 的模型 → context/max 输出字段自动填入 models.dev 参考值。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovered models now include context-window and maximum-output limits when available.
  * Model settings can be automatically prefilled when selecting a discovered model.
  * Model metadata is cached for faster discovery and remains available during temporary service issues.
* **Bug Fixes**
  * Added safer fallback behavior when model metadata cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->