### PR TITLE
fix(flow): keep /api-manager and settings-shell provider registries in sync

### DIFF
--- a/packages/pi-maestro-flow/src/providers/api-provider-config.ts
+++ b/packages/pi-maestro-flow/src/providers/api-provider-config.ts
@@ -646,7 +646,7 @@ export function registerApiProviderConfigs(
         pi.registerProvider(provider.id, configuredProviderRegistration(provider.id, modelsPath));
       }
     }
-    for (const id of managedProviderIdsSync(defaultsPath)) {
+    for (const id of managedProviderIdsSync(defaultsPath, modelsPath)) {
       if (findPreset(id) || !hasEnabledProviderSync(id, modelsPath)) continue;
       pi.registerProvider(id, configuredProviderRegistration(id, modelsPath));
     }

--- a/packages/pi-maestro-flow/src/providers/api-provider-ops.ts
+++ b/packages/pi-maestro-flow/src/providers/api-provider-ops.ts
@@ -93,6 +93,7 @@ const OPS_CATALOGS = {
     "menu.reset": "Reset a Provider",
     "menu.export": "Export API configuration to a file",
     "menu.import": "Import API configuration from a file",
+    "provider.emptyGuide": "No manageable Provider connection yet. Create one via /api-manager configure (Add or edit a model) → add a model and enter a new Provider ID; it becomes manageable here after saving.",
     "export.empty": "No API Manager managed Provider is configured; nothing to export.",
     "export.done": "Exported {providers} Providers ({models} models)",
     "export.saved": "Export file: {path}",
@@ -136,6 +137,7 @@ const OPS_CATALOGS = {
     "menu.reset": "重置 Provider",
     "menu.export": "导出 API 配置到文件",
     "menu.import": "从文件导入 API 配置",
+    "provider.emptyGuide": "暂无可管理的 Provider 连接。请通过 /api-manager configure（新增或修改模型）→ 新增模型时输入新的 Provider ID 来创建连接，保存后即可在此管理。",
     "export.empty": "尚未配置 API Manager 管理的 Provider，无可导出内容。",
     "export.done": "已导出 {providers} 个 Provider（{models} 个模型）",
     "export.saved": "导出文件：{path}",
@@ -354,7 +356,7 @@ export async function listProviders(
       defaultsPath,
     );
   }
-  for (const id of managedProviderIdsSync(defaultsPath)) {
+  for (const id of managedProviderIdsSync(defaultsPath, modelsPath)) {
     if (findPreset(id) || !isRecord(providers[id])) continue;
     const config = providers[id];
     const name = typeof config.name === "string" && config.name ? config.name : id;
@@ -1175,7 +1177,7 @@ export async function chooseProvider(
       target: { kind: "preset", preset },
     });
   }
-  for (const id of managedProviderIdsSync(defaultsPath)) {
+  for (const id of managedProviderIdsSync(defaultsPath, modelsPath)) {
     if (findPreset(id) || !await isProviderConfigured(id, modelsPath)) continue;
     const name = await channelDisplayName(id, modelsPath);
     options.push({
@@ -1186,7 +1188,10 @@ export async function chooseProvider(
       target: { kind: "custom", id },
     });
   }
-  if (options.length === 0) return undefined;
+  if (options.length === 0) {
+    ctx.ui.notify(opsText("provider.emptyGuide"), "info");
+    return undefined;
+  }
   const choice = await ctx.ui.select("选择 Provider（连接级操作）", options.map((entry) => entry.label));
   return options.find((entry) => entry.label === choice)?.target;
 }
@@ -1229,7 +1234,7 @@ export async function buildGlobalModelOptions(
   const root = await readModelsRoot(modelsPath);
   const providers = isRecord(root.providers) ? root.providers : {};
   const options: GlobalModelOption[] = [];
-  for (const providerId of modelCentricProviderOrder(defaultsPath)) {
+  for (const providerId of modelCentricProviderOrder(defaultsPath, modelsPath)) {
     const config = providers[providerId];
     if (!isRecord(config)) continue;
     const models = Array.isArray(config.models) ? config.models.filter(isRecord) : [];
@@ -1250,10 +1255,10 @@ export async function buildGlobalModelOptions(
 }
 
 /** Presets first, then managed user-defined Providers; models remain a flat list. */
-export function modelCentricProviderOrder(defaultsPath: string): string[] {
+export function modelCentricProviderOrder(defaultsPath: string, modelsPath?: string): string[] {
   return [
     ...PROVIDERS.map((preset) => preset.id),
-    ...managedProviderIdsSync(defaultsPath).filter((id) => !findPreset(id)),
+    ...managedProviderIdsSync(defaultsPath, modelsPath).filter((id) => !findPreset(id)),
   ];
 }
 
@@ -1274,7 +1279,7 @@ export async function configureNewModel(
       target: { kind: "preset", preset },
     });
   }
-  for (const id of managedProviderIdsSync(defaultsPath)) {
+  for (const id of managedProviderIdsSync(defaultsPath, modelsPath)) {
     if (findPreset(id) || !await isProviderConfigured(id, modelsPath)) continue;
     const name = await channelDisplayName(id, modelsPath);
     options.push({
@@ -1748,10 +1753,37 @@ export async function deleteProviderThinkingDefaults(
   });
 }
 
-export function managedProviderIdsSync(defaultsPath: string): string[] {
+export function managedProviderIdsSync(defaultsPath: string, modelsPath?: string): string[] {
   try {
     const root = JSON.parse(readFileSync(defaultsPath, "utf8")) as unknown;
-    return isRecord(root) ? managedProviderIds(root) : [];
+    if (!isRecord(root)) return [];
+    if (!("managedProviders" in root) && !("managedChannels" in root)) {
+      // api-manager.json lost its managed section (e.g. an external edit or a
+      // migration that rewrote the file). Fall back to every enabled custom
+      // provider already present in models.json so /api-manager does not
+      // silently forget them; an explicit (even empty) list is honored as-is.
+      if (modelsPath) return inferredManagedProviderIds(modelsPath);
+      return [];
+    }
+    return managedProviderIds(root);
+  } catch {
+    return [];
+  }
+}
+
+/** Enabled non-preset providers present in models.json, as a fallback managed list. */
+export function inferredManagedProviderIds(modelsPath: string): string[] {
+  try {
+    const parsed = JSON.parse(readFileSync(modelsPath, "utf8")) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.providers)) return [];
+    return Object.entries(parsed.providers)
+      .filter(([id, config]) =>
+        !findPreset(id)
+        && isRecord(config)
+        && providerEnabled(config),
+      )
+      .map(([id]) => id)
+      .sort();
   } catch {
     return [];
   }
@@ -2033,13 +2065,13 @@ export function defaultApiManagerExportPath(modelsPath: string): string {
 }
 
 /** Provider ids owned by the API Manager: configured presets plus managed user-defined Providers. */
-function apiManagerOwnedIds(modelsRoot: Record<string, unknown>, defaultsPath: string): string[] {
+function apiManagerOwnedIds(modelsRoot: Record<string, unknown>, defaultsPath: string, modelsPath: string): string[] {
   const providers = isRecord(modelsRoot.providers) ? modelsRoot.providers : {};
   const ids: string[] = [];
   for (const preset of PROVIDERS) {
     if (isRecord(providers[preset.id])) ids.push(preset.id);
   }
-  for (const id of managedProviderIdsSync(defaultsPath)) {
+  for (const id of managedProviderIdsSync(defaultsPath, modelsPath)) {
     if (!findPreset(id) && !ids.includes(id) && isRecord(providers[id])) ids.push(id);
   }
   return ids;
@@ -2060,7 +2092,7 @@ export async function buildApiManagerExport(
 ): Promise<Record<string, unknown>> {
   const root = await readModelsRoot(modelsPath);
   const providers = isRecord(root.providers) ? root.providers : {};
-  const ids = apiManagerOwnedIds(root, defaultsPath);
+  const ids = apiManagerOwnedIds(root, defaultsPath, modelsPath);
   const exported: Record<string, Record<string, unknown>> = {};
   for (const id of ids) {
     const entry = providers[id];

--- a/packages/pi-maestro-flow/src/settings/api-manager-settings-provider.ts
+++ b/packages/pi-maestro-flow/src/settings/api-manager-settings-provider.ts
@@ -22,7 +22,7 @@ import {
 import { SETTINGS_SECRET_SET_PLACEHOLDER } from "pi-maestro-settings-core/v1/schema";
 import { loadApiRetrySettings, saveApiRetrySettings } from "../providers/api-provider-config.ts";
 import { NETWORK_RETRY_POLICY } from "pi-maestro-teammate/v1/retry";
-import { readModelsRoot, writeModelsRoot } from "../providers/api-provider-ops.ts";
+import { addManagedProvider, readModelsRoot, writeModelsRoot } from "../providers/api-provider-ops.ts";
 import {
   AGENT_CACHE_RETENTION_DEFAULT,
   applyCacheRetentionEnv,
@@ -125,6 +125,7 @@ export interface ApiManagerSettingsProviderOptions {
   actions?: Readonly<Record<string, ApiManagerAction>>;
   getModelsPath?: () => string;
   getSettingsPath?: () => string;
+  getDefaultsPath?: () => string;
   getAgentDir?: () => string;
 }
 
@@ -642,6 +643,7 @@ export function createApiManagerSettingsProvider(
   const instanceId = randomUUID();
   const getModelsPath = options.getModelsPath ?? (() => `${getAgentDir()}/models.json`);
   const getSettingsPath = options.getSettingsPath ?? (() => `${getAgentDir()}/settings.json`);
+  const getDefaultsPath = options.getDefaultsPath ?? (() => `${getAgentDir()}/api-manager.json`);
   const originals = new Map<string, { models: string; settings: string }>();
   const preparedChanges = new Map<string, readonly SettingsChange[]>();
 
@@ -970,6 +972,13 @@ export function createApiManagerSettingsProvider(
           }
           const nextRoot = { ...data.modelsRoot, providers: nextProviders };
           await writeModelsRoot(nextRoot, modelsPath, await existsFile(modelsPath));
+          // The settings shell only writes models.json; /api-manager's provider
+          // registry is keyed off api-manager.json `managedProviders`. Mirror new
+          // custom provider ids there so both surfaces stay in sync (a provider
+          // added here would otherwise be invisible to /api-manager list/show).
+          for (const id of Object.keys(nextProviders)) {
+            await addManagedProvider(getDefaultsPath(), id);
+          }
           modelsWritten = true;
         }
         const retryBase = changes.find((change) => change.key === "api.retry.baseDelayMs");

--- a/packages/pi-maestro-flow/test/api-manager-settings-provider.test.ts
+++ b/packages/pi-maestro-flow/test/api-manager-settings-provider.test.ts
@@ -11,20 +11,24 @@ interface Harness {
   provider: ReturnType<typeof createApiManagerSettingsProvider>;
   modelsPath: string;
   settingsPath: string;
+  defaultsPath: string;
   context: SettingsContextV1;
 }
 
-function harness(initialModels: Record<string, unknown> = {}, initialSettings: Record<string, unknown> = {}): Harness {
+function harness(initialModels: Record<string, unknown> = {}, initialSettings: Record<string, unknown> = {}, initialDefaults: Record<string, unknown> | null = null): Harness {
   const directory = mkdtempSync(join(tmpdir(), "api-settings-e2e-"));
   const modelsPath = join(directory, "models.json");
   const settingsPath = join(directory, "settings.json");
+  const defaultsPath = join(directory, "api-manager.json");
   writeFileSync(modelsPath, JSON.stringify(initialModels, null, 2));
   writeFileSync(settingsPath, JSON.stringify(initialSettings, null, 2));
+  if (initialDefaults !== null) writeFileSync(defaultsPath, JSON.stringify(initialDefaults, null, 2));
   const provider = createApiManagerSettingsProvider({
     getModelsPath: () => modelsPath,
     getSettingsPath: () => settingsPath,
+    getDefaultsPath: () => defaultsPath,
   });
-  return { provider, modelsPath, settingsPath, context: { cwd: "/project", locale: "en" } };
+  return { provider, modelsPath, settingsPath, defaultsPath, context: { cwd: "/project", locale: "en" } };
 }
 
 test("api manager read surfaces providers with a masked apiKey placeholder", async () => {
@@ -456,4 +460,64 @@ test("agent header presets cover all sub2api agent identities", () => {
   assert.match(AGENT_HEADER_PRESETS["codex"]["User-Agent"], /^codex-tui\//);
   assert.match(AGENT_HEADER_PRESETS["grok"]["User-Agent"], /^xai-grok-workspace\//);
   assert.match(AGENT_HEADER_PRESETS["antigravity"]["User-Agent"], /^antigravity\//);
+});
+
+test("api manager commit syncs new custom providers into api-manager.json managedProviders", async () => {
+  const { provider, modelsPath, defaultsPath, context } = harness(
+    { providers: {} },
+    { retry: {} },
+    { version: 1, modelDefaults: {} },
+  );
+  const transactionId = "tx-managed";
+  const prepared = await provider.prepare!({
+    context,
+    transactionId,
+    changes: [
+      {
+        operation: "set",
+        key: "api.providers",
+        scope: "global",
+        value: [
+          { id: "new-vendor", baseUrl: "https://n.example.com/v1", api: "anthropic-messages", enabled: true, apiKey: "sk-new" },
+        ],
+      },
+    ],
+    expectedRevisions: [],
+  });
+  assert.equal(prepared.prepared, true);
+  await provider.commit!({ context, transactionId, prepareToken: transactionId });
+
+  const models = JSON.parse(readFileSync(modelsPath, "utf8")) as { providers: Record<string, unknown> };
+  assert.ok(models.providers["new-vendor"], "provider written to models.json");
+  const defaults = JSON.parse(readFileSync(defaultsPath, "utf8")) as { managedProviders?: string[] };
+  assert.ok(defaults.managedProviders?.includes("new-vendor"), "new custom provider synced into api-manager.json managedProviders");
+});
+
+test("api manager commit appends to existing managedProviders without duplicating preset ids", async () => {
+  const { provider, defaultsPath, context } = harness(
+    { providers: { "maestro-openai": { baseUrl: "https://g.example.com/v1", api: "openai-responses", enabled: true, apiKey: "sk" } } },
+    { retry: {} },
+    { version: 1, managedProviders: ["existing-vendor"], modelDefaults: {} },
+  );
+  const transactionId = "tx-managed-2";
+  const prepared = await provider.prepare!({
+    context,
+    transactionId,
+    changes: [
+      {
+        operation: "set",
+        key: "api.providers",
+        scope: "global",
+        value: [
+          { id: "existing-vendor", baseUrl: "https://n.example.com/v1", api: "openai-responses", enabled: true, apiKey: "sk2" },
+        ],
+      },
+    ],
+    expectedRevisions: [],
+  });
+  assert.equal(prepared.prepared, true);
+  await provider.commit!({ context, transactionId, prepareToken: transactionId });
+
+  const defaults = JSON.parse(readFileSync(defaultsPath, "utf8")) as { managedProviders?: string[] };
+  assert.deepEqual(defaults.managedProviders, ["existing-vendor"], "existing managed id kept without duplication");
 });

--- a/packages/pi-maestro-flow/test/api-provider-config.test.ts
+++ b/packages/pi-maestro-flow/test/api-provider-config.test.ts
@@ -46,6 +46,12 @@ import {
   setApiProviderEnabled,
 } from "../src/providers/api-provider-config.ts";
 import {
+  chooseProvider,
+  inferredManagedProviderIds,
+  managedProviderIdsSync,
+  modelCentricProviderOrder,
+} from "../src/providers/api-provider-ops.ts";
+import {
   applyCacheRetentionEnv,
   loadAgentCacheRetention,
   loadCacheRetentionSetting,
@@ -2937,7 +2943,9 @@ test("startup keeps multiple models under one Provider and preserves model defau
   assert.deepEqual(JSON.parse(readFileSync(modelsPath, "utf8")), JSON.parse(modelsBytes));
   assert.equal(readFileSync(defaultsPath, "utf8"), defaultsBytes);
   assert.equal(readFileSync(settingsPath, "utf8"), settingsBytes);
-  assert.deepEqual([...registrations.keys()], ["maestro-qwen"]);
+  // maestro-qwen is a configured preset; “untouched” is an enabled custom provider
+  // that api-manager.json does not list, so the managed fallback picks it up.
+  assert.deepEqual([...registrations.keys()], ["maestro-qwen", "untouched"]);
   assert.deepEqual(
     registrations.get("maestro-qwen")?.models.map((m: any) => m.id),
     ["qwen3.8-max", "deepseek-v4-flash"],
@@ -4007,4 +4015,65 @@ test("applyModelFilters is a no-op when no filters are configured", async (t) =>
   const ctx = { modelRegistry: { getAvailable: () => [] }, ui: { notify() {} } } as any;
   await applyModelFilters(pi, ctx, defaultsPath);
   assert.equal(registered.length, 0);
+});
+test("managedProviderIdsSync falls back to enabled custom providers when api-manager.json lost its managed section", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-api-managed-fallback-"));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const modelsPath = join(tempDir, "models.json");
+  const defaultsPath = join(tempDir, "api-manager.json");
+  writeFileSync(modelsPath, JSON.stringify({
+    version: 1,
+    providers: {
+      "maestro-openai": { baseUrl: "https://api.openai.com/v1", api: "openai-responses", enabled: true, models: [{ id: "gpt-5.6" }] },
+      "custom-a": { baseUrl: "https://a.example.com/v1", api: "openai-responses", enabled: true, models: [{ id: "m1" }] },
+      "custom-b": { baseUrl: "https://b.example.com/v1", api: "openai-responses", enabled: false, models: [{ id: "m2" }] },
+    },
+  }, null, 2));
+  // api-manager.json exists but has no managedProviders section (the breakage being fixed)
+  writeFileSync(defaultsPath, JSON.stringify({ version: 1, modelDefaults: {} }, null, 2));
+
+  assert.deepEqual(managedProviderIdsSync(defaultsPath, modelsPath), ["custom-a"]);
+  assert.deepEqual(inferredManagedProviderIds(modelsPath), ["custom-a"]);
+  assert.deepEqual(modelCentricProviderOrder(defaultsPath, modelsPath).filter((id) => !id.startsWith("maestro-")), ["custom-a"]);
+});
+
+test("managedProviderIdsSync honors an explicit empty managed list instead of falling back", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-api-managed-explicit-"));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const modelsPath = join(tempDir, "models.json");
+  const defaultsPath = join(tempDir, "api-manager.json");
+  writeFileSync(modelsPath, JSON.stringify({
+    version: 1,
+    providers: {
+      "custom-a": { baseUrl: "https://a.example.com/v1", api: "openai-responses", enabled: true, models: [{ id: "m1" }] },
+    },
+  }, null, 2));
+  writeFileSync(defaultsPath, JSON.stringify({ version: 1, managedProviders: [], modelDefaults: {} }, null, 2));
+
+  assert.deepEqual(managedProviderIdsSync(defaultsPath, modelsPath), []);
+  assert.deepEqual(managedProviderIdsSync(defaultsPath), []);
+});
+
+test("chooseProvider guides the user to the add-model entry when no provider connection exists", async (t) => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-api-choose-empty-"));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const modelsPath = join(tempDir, "models.json");
+  const defaultsPath = join(tempDir, "api-manager.json");
+  writeFileSync(modelsPath, JSON.stringify({ version: 1, providers: {} }, null, 2));
+  writeFileSync(defaultsPath, JSON.stringify({ version: 1 }, null, 2));
+  const notices: string[] = [];
+  const ctx = {
+    hasUI: true,
+    ui: {
+      notify(message: string) { notices.push(message); },
+      select: async () => undefined,
+    },
+    modelRegistry: { getAvailable: () => [], getAll: () => [] },
+  } as any;
+  const target = await chooseProvider(ctx, modelsPath, defaultsPath);
+  assert.equal(target, undefined);
+  assert.equal(notices.length, 1);
+  // Guide message exists in both catalogs; en is the test-default locale.
+  assert.match(notices[0], /Add or edit a model|新增或修改模型/);
+  assert.match(notices[0], /new Provider ID|新的 Provider ID/);
 });


### PR DESCRIPTION
## 问题背景

`/api-manager` 的 provider 注册/列表 (`list/show/export/import` 及选择器) 以 `~/.pi/agent/api-manager.json` 的 `managedProviders` 段为"归属"清单；而 `/maestro-settings` 的 API Manager（settings shell provider）新增 provider 时**只写 models.json，从不更新 api-manager.json**。结果：

1. 通过 `/maestro-settings` 新增的 provider 在 `/api-manager` 中全部不可见（list 只显示 3 个未配置预设、0 模型）
2. `api-manager.json` 的 `managedProviders` 一旦丢失（外部编辑/迁移重写文件），`/api-manager` 所有依赖该段的入口静默失效，且无任何提示

## 修复内容（3 处）

1. **`api-manager-settings-provider.ts`**：commit 写回 providers 后，对每个自定义 provider id 调用 `addManagedProvider` 同步 `api-manager.json` 的 `managedProviders` —— 两套 API Manager 逻辑（`/api-manager` 命令与 `/maestro-settings` settings shell）从此保持一致。新增 `getDefaultsPath` 选项。

2. **`api-provider-ops.ts` `managedProviderIdsSync`**：当 `api-manager.json` **缺少** `managedProviders`/`managedChannels` 段时，回退为从 models.json 推导已启用（`enabled !== false`）的非预设 provider（新增 `inferredManagedProviderIds`），防止配置段丢失后静默失效。显式存在的空列表仍按"不托管"语义保留。签名增加可选 `modelsPath`，所有 6 处调用点（list/chooseProvider/global picker/configureNewModel/export/register 循环）均已传入。

3. **`chooseProvider` 空列表引导**：当没有任何可管理的 Provider 连接时，不再静默 return；改为 notify 显式引导用户走 `/api-manager configure（新增或修改模型）→ 新增模型→输入新的 Provider ID` 创建连接（en/zh-CN 双语 catalog）。

## 测试

- `api-manager-settings-provider.test.ts`：+2 测试（commit 同步 managedProviders、已有列表追加不重复）→ 24 全过
- `api-provider-config.test.ts`：+3 测试（managed 缺失回退推导、显式空列表不回退、chooseProvider 空列表引导）→ 55 pass（与 master 基线 30 fail 一致，无新增失败；基线失败为 locale/环境问题）
- `model-discovery.test.ts` / `cost-backfill.test.ts`：通过
- typecheck：改动文件零错误（仓库既有 `ws` 类型声明缺失与本改动无关）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom API providers are now discovered automatically when no managed-provider list is configured.
  * Provider and model selection now preserves configured ordering and recognizes newly added providers.
  * Saving provider settings synchronizes custom providers with the managed-provider configuration.

* **Bug Fixes**
  * Prevented duplicate provider entries when updating existing configurations.
  * Added guidance when no managed providers are available, in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->