### PR TITLE
fix(mcp): allow standing down the vendored MCP adapter so `run-control` survives

### DIFF
--- a/packages/pi-maestro-flow/src/extension/index.ts
+++ b/packages/pi-maestro-flow/src/extension/index.ts
@@ -1621,13 +1621,34 @@ export default function registerMaestroExtension(pi: ExtensionAPI): void {
   }
 
   let mcpAdapterHandle: ReturnType<typeof registerMcpAdapter> | undefined;
-  try {
-    mcpAdapterHandle = registerMcpAdapter(pi);
-  } catch (error) {
-    // MCP 注册失败不得阻断 Maestro 现有工具与 Provider。
+  // The vendored MCP adapter registers the tool "mcp" and the flag
+  // "--mcp-config" unconditionally. Both collide with the standalone
+  // `pi-mcp-adapter` package, and the host rejects the WHOLE extension on a
+  // name collision -- so `run-control` (registered further down) never
+  // registers, and the entire Session/Run lifecycle silently loses its
+  // transport while every /maestro-* skill still appears to work.
+  //
+  // The try/catch below cannot prevent this: the host rejects the extension
+  // before any throw reaches it. Detecting a peer-owned "mcp" tool is also
+  // not possible here -- `pi.getAllTools()` during extension loading fails
+  // with "Extension runtime not initialized. Action methods cannot be called
+  // during extension loading." So the escape hatch has to be declarative.
+  //
+  // Default behaviour is unchanged; set MAESTRO_DISABLE_VENDORED_MCP=1 on a
+  // host that gets its MCP surface from `pi-mcp-adapter` instead.
+  if (process.env.MAESTRO_DISABLE_VENDORED_MCP === "1") {
     console.error(
-      `[maestro] MCP adapter registration warning: ${error instanceof Error ? error.message : String(error)}`,
+      "[maestro] Vendored MCP adapter not registered (MAESTRO_DISABLE_VENDORED_MCP=1); Maestro's own tools are unaffected.",
     );
+  } else {
+    try {
+      mcpAdapterHandle = registerMcpAdapter(pi);
+    } catch (error) {
+      // MCP 注册失败不得阻断 Maestro 现有工具与 Provider。
+      console.error(
+        `[maestro] MCP adapter registration warning: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   registerMaestroPackageResources(pi);


### PR DESCRIPTION
Closes #23.

## Problem

The vendored MCP adapter registers the tool `mcp` and the flag `--mcp-config` unconditionally (`src/mcp/index.ts:335`, via `registerMcpAdapter(pi)` at `src/extension/index.ts:1626`). Both collide with the standalone `pi-mcp-adapter` package, and Pi rejects the **entire extension** on a name collision:

```
Error: Failed to load extension ".../pi-maestro-flow/src/extension/index.ts":
  Tool "mcp" conflicts with ".../pi-mcp-adapter/index.ts"
Error: Failed to load extension ".../pi-maestro-flow/src/extension/index.ts":
  Flag "--mcp-config" conflicts with ".../pi-mcp-adapter/index.ts"
```

Because `run-control` is registered further down the same function (line 2027), it never registers — so **every maestro Session/Run mutation path silently loses its transport** while all `/maestro-*` skills continue to load and appear to work.

`/maestro-ralph` then reads its own instruction to mutate only through `run-control`, cannot find the tool, is explicitly forbidden the Bash fallback, and completes the task with ordinary `edit`/`write`/`bash` calls while reporting success: no Session, no Runs, no decision receipts, nothing for `maestro knowledge promote`. In our project that cost a day of unrecorded work before anyone noticed, and it took a while to believe because the symptom looks like agent laziness rather than a missing tool.

## Two approaches that do not work

- **The existing `try/catch`.** It cannot help — the host rejects the extension before any throw reaches the handler. The intent in that comment (*"MCP 注册失败不得阻断 Maestro 现有工具与 Provider"*) is exactly right; the mechanism just cannot deliver it.
- **Detecting a peer-owned `mcp` tool and standing down automatically.** Tried first, since it needs no configuration. At registration time `pi.getAllTools()` throws `Extension runtime not initialized. Action methods cannot be called during extension loading.`

So the escape hatch has to be declarative.

## Change

`MAESTRO_DISABLE_VENDORED_MCP=1` skips only the vendored adapter, leaving every maestro tool intact.

**Default behaviour is deliberately unchanged.** Without the variable the adapter registers exactly as before, so any host relying on it keeps its `mcp` tool and this is a no-op for them. Only hosts that get their MCP surface from `pi-mcp-adapter` need to set it — and for them it is the difference between a working `run-control` and a silently ungoverned agent.

## Verification

Pi 0.85.1 / pi-maestro-flow 0.30.0 / maestro-flow CLI 0.5.86, with `pi-mcp-adapter` installed:

| | result |
|---|---|
| unset | both collision errors, extension rejected, no `run-control` — upstream behaviour, preserved |
| `=1` | clean start; `run-control`, `mcp`, `mcpScript`, `todo`, `teammate`, `goal` all present, plus `mcp__playwright` / `mcp__context7` / `mcp__context_mode` from the standalone adapter |

## Note on the alternative

If you would rather fix this without configuration, the shape that would work is deferring the vendored MCP registration to a point where the runtime is initialised (e.g. a `session_start` handler) and skipping it there if `mcp` already exists. That is a larger change to this package's startup ordering, so I have not attempted it — happy to if you prefer that direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added an option to disable the built-in MCP adapter when needed, preventing tool-name conflicts with an external MCP adapter.
  - Logs an error when the built-in adapter is intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->